### PR TITLE
Add downloading quarto before building docs in GH actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env
 
+      - name: Install Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
       - name: Install docs dependencies
         run: uv sync --group docs
 


### PR DESCRIPTION
## Summary

This PR adds a step in GH Actions for deploying documents to download Quarto. This is needed to deploy documentations properly in GH

## Implementation

main.yml file was edited in the ```check-docs``` section to download Quarto before deploying the docs using ```mkdocs build```

Closes #25 