### PR TITLE
Mark dynamic tests as xfail instead of commented out

### DIFF
--- a/tests/test_first_pass.py
+++ b/tests/test_first_pass.py
@@ -98,13 +98,11 @@ def test_building_simulation_controller():
     assert np.all(results.D_unmet_mt == 0.0)  # W
 
 
+@pytest.mark.xfail
 def test_building_simulation_controller_dynamic():
     """Test building_simulation_controller dynamic behavior (DYNAMIC - will fail)"""
-    # Has not been implemented yet
-    assert True
 
-
-"""    # DYNAMIC: TOU schedule should reduce peak consumption
+    # DYNAMIC: TOU schedule should reduce peak consumption
     hot_water = np.ones(96) * 0.1  # Constant hot water usage
 
     # Default schedule (unrestricted)
@@ -123,7 +121,6 @@ def test_building_simulation_controller_dynamic():
     tou_peak_consumption = np.sum(tou_results.E_mt[peak_intervals])
 
     assert tou_peak_consumption < default_peak_consumption, "TOU schedule should reduce peak consumption"
-"""
 
 
 def test_human_controller():
@@ -134,11 +131,10 @@ def test_human_controller():
     assert human_controller(1, 0.0, -10.0) == 0  # Default state with negative savings
 
 
+@pytest.mark.xfail
 def test_human_controller_dynamic():
     """Test human_controller dynamic behavior (DYNAMIC - will fail)"""
-    # Has not been implemented yet
-    assert True
-    """# DYNAMIC: Should switch to TOU when anticipated savings are high
+    # DYNAMIC: Should switch to TOU when anticipated savings are high
     decision = human_controller(
         current_state=1,  # Default schedule
         realized_savings=0.0,  # Not used for default→TOU decision
@@ -169,7 +165,6 @@ def test_human_controller_dynamic():
         unrealized_savings=0.0,
     )
     assert decision == 0, "Should continue TOU when realized savings are positive"
-"""
 
 
 def test_calculate_monthly_bill():
@@ -298,13 +293,11 @@ def test_simulate_annual_cycle():
         simulate_annual_cycle(empty_data)
 
 
+@pytest.mark.xfail
 def test_simulate_annual_cycle_dynamic():
     """Test simulate_annual_cycle dynamic behavior (DYNAMIC - will fail)"""
-    # Has not been implemented yet
-    assert True
 
-
-"""    # DYNAMIC: Should see some TOU adoption over the year
+    # DYNAMIC: Should see some TOU adoption over the year
     hot_water_data = np.random.rand(35040) * 0.2  # Realistic usage levels
     params = TOUParameters()
 
@@ -326,7 +319,6 @@ def test_simulate_annual_cycle_dynamic():
     monthly_results = simulate_annual_cycle(hot_water_seasonal)
     switches_by_month = [r.switching_decision for r in monthly_results]
     assert any(switch == 1 for switch in switches_by_month), "Should see switching activity with seasonal patterns"
-"""
 
 
 def test_calculate_annual_metrics():


### PR DESCRIPTION
Minor PR. Fixes #29 by moving un-finishable tests to `xfail` instead of being commented out.