### PR TITLE
Check that all load curves were downloaded for 2024 NY release

### DIFF
--- a/rate_design/ny/hp_rates/data/resstock/Justfile
+++ b/rate_design/ny/hp_rates/data/resstock/Justfile
@@ -1,3 +1,6 @@
+# Resolve project root as absolute path from this Justfile's location (works for any clone)
+project_root := absolute_path(justfile_directory() / ".." / ".." / ".." / ".." / "..")
+
 download:
   uv run bsf \
   --product resstock \
@@ -9,3 +12,10 @@ download:
   --upgrade_id "0 1 2 3 4 5" \
   --output_directory /data.sb/nrel/resstock \
   --sample 0 # All buildings
+
+test-download:
+  cd {{project_root}} && uv run python {{project_root}}/tests/test_resstock_download_to_s3.py \
+    --data_path "s3://data.sb/nrel/resstock/" \
+    --release res_2024_amy2018_2 \
+    --state NY \
+    --upgrade_id "00 01 02 03 04 05"

--- a/rate_design/ri/hp_rates/data/resstock/Justfile
+++ b/rate_design/ri/hp_rates/data/resstock/Justfile
@@ -19,5 +19,4 @@ test-download:
     --data_path "s3://data.sb/nrel/resstock/" \
     --release res_2024_amy2018_2 \
     --state RI \
-    --upgrade_id 00
-
+    --upgrade_id "00 01 02 03 04 05"

--- a/tests/test_resstock_download_to_s3.py
+++ b/tests/test_resstock_download_to_s3.py
@@ -1,0 +1,85 @@
+import argparse
+import io
+
+import polars as pl
+from cloudpathlib import S3Path
+
+
+def test_resstock_download_to_s3(
+    data_path: str, release: str, state: str, upgrade_id: str
+):
+    """Test that the resstock data is downloaded to the correct path."""
+    base = S3Path(data_path)
+    release_dir = base / release
+    if not release_dir.exists():
+        raise FileNotFoundError(f"Release directory {release_dir} does not exist")
+
+    upgrade_ids = upgrade_id.split(" ")
+    for upgrade_id in upgrade_ids:
+        # Find unique bldg_ids in the metadata
+        metadata_path = (
+            release_dir
+            / "metadata"
+            / f"state={state}"
+            / f"upgrade={upgrade_id}"
+            / "metadata.parquet"
+        )
+        if not metadata_path.exists():
+            raise FileNotFoundError(f"Metadata file {metadata_path} does not exist")
+
+        # Read via S3Path (boto3) so Polars doesn't need S3 credentials/region
+        parquet_bytes = metadata_path.read_bytes()
+        metadata_bldg_ids: pl.DataFrame = (
+            pl.read_parquet(io.BytesIO(parquet_bytes)).select("bldg_id").unique()
+        )
+
+        # Get a count of files in the load_curve_hourly_directory
+        load_curve_hourly_dir = (
+            release_dir
+            / "load_curve_hourly"
+            / f"state={state}"
+            / f"upgrade={upgrade_id}"
+        )
+        if not load_curve_hourly_dir.exists():
+            raise FileNotFoundError(
+                f"Load curve hourly directory {load_curve_hourly_dir} does not exist"
+            )
+
+        load_curve_hourly_files = list(load_curve_hourly_dir.glob("*.parquet"))
+        num_load_curve_hourly_files = len(load_curve_hourly_files)
+
+        assert num_load_curve_hourly_files == len(metadata_bldg_ids), (
+            "Number of load curve hourly files does not match number of metadata bldg_ids"
+        )
+
+    print("Test passed")
+    print("Release: ", release)
+    print("State: ", state)
+    print("Upgrade ids: ", upgrade_ids)
+    print(f"Number of load curve hourly files: {num_load_curve_hourly_files}")
+    print(f"Number of metadata bldg_ids: {len(metadata_bldg_ids)}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify resstock data download.")
+    parser.add_argument(
+        "--data_path", required=True, help="Base path for resstock data"
+    )
+    parser.add_argument(
+        "--release",
+        required=True,
+        help="Resstock release name (e.g. res_2024_amy2018_2)",
+    )
+    parser.add_argument("--state", required=True, help="State code (e.g. RI)")
+    parser.add_argument("--upgrade_id", required=True, help="Upgrade id (e.g. 00)")
+    args = parser.parse_args()
+    test_resstock_download_to_s3(
+        data_path=args.data_path,
+        release=args.release,
+        state=args.state,
+        upgrade_id=args.upgrade_id,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds python script and Justfile command that checks all `load_curve_hourly` files were downloaded (i.e. all the `bldg_id`'s included in the `metadata.parquet` file).

Closes #111 