### PR TITLE
Add EIA-861 investor-owned utility stats script

### DIFF
--- a/tests/test_get_utility_stats_from_eia861.py
+++ b/tests/test_get_utility_stats_from_eia861.py
@@ -1,0 +1,73 @@
+"""Validate the EIA-861 yearly sales dataset used by utils/get_utility_stats_from_eia861.py.
+
+Confirms required columns and customer_class values exist so the script's
+dynamic aggregation is safe. Uses the same parquet URL as the script.
+"""
+
+import polars as pl
+
+# Must match utils/get_utility_stats_from_eia861.py
+CORE_EIA861_YEARLY_SALES_URL = "https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/core_eia861__yearly_sales.parquet"
+
+REQUIRED_COLUMNS = frozenset(
+    {
+        "utility_id_eia",
+        "state",
+        "report_date",
+        "entity_type",
+        "utility_name_eia",
+        "business_model",
+        "customer_class",
+        "sales_mwh",
+        "sales_revenue",
+        "customers",
+    }
+)
+
+# Known customer classes in PUDL EIA-861 yearly sales (verified by inspection)
+EXPECTED_CUSTOMER_CLASSES = frozenset(
+    {
+        "commercial",
+        "industrial",
+        "other",
+        "residential",
+        "transportation",
+    }
+)
+
+
+def test_eia861_yearly_sales_has_required_columns():
+    """Dataset must have all columns the utility stats script aggregates on."""
+    df = pl.read_parquet(CORE_EIA861_YEARLY_SALES_URL)
+    missing = REQUIRED_COLUMNS - set(df.columns)
+    assert not missing, f"Missing columns: {missing}"
+
+
+def test_eia861_yearly_sales_customer_class_values():
+    """customer_class must match expected set so per-class columns are predictable.
+
+    Uses exact set equality: fails if the dataset has extra classes (unaccounted for)
+    or is missing any expected class.
+    """
+    df = pl.read_parquet(CORE_EIA861_YEARLY_SALES_URL)
+    classes = df.select("customer_class").unique().to_series().cast(pl.Utf8).to_list()
+    actual = frozenset(classes)
+    assert actual == EXPECTED_CUSTOMER_CLASSES, (
+        f"customer_class values changed: expected {EXPECTED_CUSTOMER_CLASSES}, got {actual}"
+    )
+
+
+def test_eia861_yearly_sales_has_investor_owned_data_for_sample_state():
+    """At least one state (NY) has Investor Owned rows with all customer classes."""
+    df = (
+        pl.read_parquet(CORE_EIA861_YEARLY_SALES_URL)
+        .filter(pl.col("state") == "NY")
+        .filter(pl.col("entity_type") == "Investor Owned")
+    )
+    assert df.height > 0, "No NY Investor Owned rows in dataset"
+    classes_in_data = (
+        df.select("customer_class").unique().to_series().cast(pl.Utf8).to_list()
+    )
+    assert frozenset(classes_in_data) == EXPECTED_CUSTOMER_CLASSES, (
+        f"NY IOU data missing some customer classes: got {set(classes_in_data)}"
+    )

--- a/utils/get_utility_stats_from_eia861.py
+++ b/utils/get_utility_stats_from_eia861.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Print investor-owned utility stats for a state as CSV to stdout.
+
+Uses EIA-861 yearly sales data (PUDL). Filtered to Investor Owned only.
+Self-contained: no imports from the rate-design-platform package.
+
+Customer classes are discovered at runtime from the parquet (commercial,
+industrial, other, residential, transportation). Dataset schema and
+customer_class values are validated in tests/test_get_utility_stats_from_eia861.py.
+
+Freshness: Each row has report_date (EIA-861 reporting period). The script uses
+the latest report_date per utility; the parquet has no "file built" date (source:
+PUDL Catalyst Coop nightly, EIA-861 temporal coverage 2001-2024).
+
+Columns: utility_id_eia, utility_name, business_model, entity_type, report_date,
+total_sales_mwh, total_sales_revenue, then for each customer class
+({class}_sales_mwh, {class}_sales_revenue, {class}_customers).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import polars as pl
+
+# EIA-861 yearly sales (PUDL Catalyst Coop nightly)
+CORE_EIA861_YEARLY_SALES_URL = "https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/core_eia861__yearly_sales.parquet"
+
+VALID_STATE_CODES = frozenset(
+    {
+        "al",
+        "ak",
+        "az",
+        "ar",
+        "ca",
+        "co",
+        "ct",
+        "de",
+        "fl",
+        "ga",
+        "hi",
+        "id",
+        "il",
+        "in",
+        "ia",
+        "ks",
+        "ky",
+        "la",
+        "me",
+        "md",
+        "ma",
+        "mi",
+        "mn",
+        "ms",
+        "mo",
+        "mt",
+        "ne",
+        "nv",
+        "nh",
+        "nj",
+        "nm",
+        "ny",
+        "nc",
+        "nd",
+        "oh",
+        "ok",
+        "or",
+        "pa",
+        "ri",
+        "sc",
+        "sd",
+        "tn",
+        "tx",
+        "ut",
+        "vt",
+        "va",
+        "wa",
+        "wv",
+        "wi",
+        "wy",
+        "dc",
+    }
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Print investor-owned utility stats for a state as CSV to stdout."
+    )
+    parser.add_argument(
+        "state",
+        type=str,
+        metavar="STATE",
+        help="Two-letter state abbreviation (e.g. NY, CA).",
+    )
+    args = parser.parse_args()
+
+    state_raw = args.state.strip().upper()
+    if state_raw.lower() not in VALID_STATE_CODES:
+        parser.error(f"Invalid state '{args.state}'. Use a two-letter US state or DC.")
+
+    df = (
+        pl.read_parquet(CORE_EIA861_YEARLY_SALES_URL)
+        .filter(pl.col("state") == state_raw)
+        .filter(pl.col("entity_type") == "Investor Owned")
+        .filter(
+            pl.col("report_date") == pl.col("report_date").max().over("utility_id_eia")
+        )
+    )
+
+    customer_classes = (
+        df.select("customer_class")
+        .unique()
+        .sort("customer_class")
+        .to_series()
+        .to_list()
+    )
+
+    agg_exprs = [
+        pl.col("utility_name_eia").last().alias("utility_name"),
+        pl.col("business_model").last().alias("business_model"),
+        pl.col("entity_type").last().alias("entity_type"),
+        pl.col("report_date").first().alias("report_date"),
+        pl.col("sales_mwh").sum().alias("total_sales_mwh"),
+        pl.col("sales_revenue").sum().alias("total_sales_revenue"),
+    ]
+    for c in customer_classes:
+        agg_exprs.append(
+            pl.col("sales_mwh")
+            .filter(pl.col("customer_class") == c)
+            .sum()
+            .alias(f"{c}_sales_mwh")
+        )
+        agg_exprs.append(
+            pl.col("sales_revenue")
+            .filter(pl.col("customer_class") == c)
+            .sum()
+            .alias(f"{c}_sales_revenue")
+        )
+        agg_exprs.append(
+            pl.col("customers")
+            .filter(pl.col("customer_class") == c)
+            .sum()
+            .alias(f"{c}_customers")
+        )
+
+    result = (
+        df.group_by("utility_id_eia")
+        .agg(agg_exprs)
+        .sort(["total_sales_mwh", "utility_name"], descending=[True, False])
+        .with_columns(pl.col("utility_id_eia").cast(pl.Int64))
+    )
+
+    # Column order: id, name, business_model, entity_type, totals, then per-class triplets
+    class_cols = []
+    for c in customer_classes:
+        class_cols.extend([f"{c}_sales_mwh", f"{c}_sales_revenue", f"{c}_customers"])
+    result = result.select(
+        [
+            "utility_id_eia",
+            "utility_name",
+            "business_model",
+            "entity_type",
+            "report_date",
+            "total_sales_mwh",
+            "total_sales_revenue",
+        ]
+        + class_cols
+    )
+
+    result.write_csv(sys.stdout)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a small CLI and tests to pull **investor-owned utility (IOU) stats by state** from EIA-861 yearly sales (PUDL), and output CSV to stdout. Closes #154.

## How it works

- **Source:** [PUDL Catalyst Coop](https://catalystcoop-pudl.readthedocs.io/) nightly parquet: `core_eia861__yearly_sales` (EIA Form 861 – Annual Electric Power Industry Report).
- **Filter:** State (required arg) + `entity_type == "Investor Owned"`; for each utility we keep the **latest** `report_date` (reporting year).
- **Aggregation:** One row per utility with:
  - **Totals:** `total_sales_mwh`, `total_sales_revenue` (all customer classes).
  - **Per customer class:** For each of commercial, industrial, other, residential, transportation: `{class}_sales_mwh`, `{class}_sales_revenue`, `{class}_customers`.
- **Freshness:** Each row includes `report_date` (EIA reporting period). No “file built” date in the parquet; source is PUDL nightly (EIA-861 coverage 2001–2024).

Customer classes are discovered at runtime from the data; tests assert the expected schema and `customer_class` set so new/removed classes are caught.

## Example output (NY, first 4 rows)

| utility_id_eia | utility_name | business_model | entity_type | report_date | total_sales_mwh | total_sales_revenue | residential_sales_mwh | residential_customers | … |
|----------------|--------------|----------------|-------------|-------------|-----------------|---------------------|------------------------|------------------------|---|
| 4226 | Consolidated Edison Co-NY Inc | retail | Investor Owned | 2024-01-01 | 52,425,972 | 10,723,692,000 | 13,643,968 | 3,064,038 | … |
| 13573 | Niagara Mohawk Power Corp. | retail | Investor Owned | 2024-01-01 | 32,718,094 | 2,986,044,400 | 11,833,895 | 1,532,294 | … |
| 13511 | New York State Elec & Gas Corp | retail | Investor Owned | 2024-01-01 | 15,231,769 | 1,764,984,800 | 6,919,839 | 792,300 | … |
| 16183 | Rochester Gas & Electric Corp | retail | Investor Owned | 2024-01-01 | 6,871,716 | 812,878,800 | 2,842,349 | 351,481 | … |

(Full CSV also includes commercial/industrial/other/transportation columns and is sorted by `total_sales_mwh` descending.)

## Usage

```bash
uv run python utils/get_utility_stats_from_eia861.py NY          # stdout
uv run python utils/get_utility_stats_from_eia861.py NY > ny_iou.csv
uv run pytest tests/test_get_utility_stats_from_eia861.py -v    # dataset validation
```

## Files

- **`utils/get_utility_stats_from_eia861.py`** – Self-contained script (no package imports); only `argparse`, `sys`, `polars`. Polars already in project deps.
- **`tests/test_get_utility_stats_from_eia861.py`** – Validates parquet has required columns and expected `customer_class` set (fails on new or missing classes).
