### PR TITLE
Add monthly load curve aggregation for res_2024_amy2018_2_sb NY

### DIFF
--- a/context/code/data/resstock_data_preparation_run_order.md
+++ b/context/code/data/resstock_data_preparation_run_order.md
@@ -1,6 +1,6 @@
 # ResStock data preparation: run order
 
-This document outlines the current `data/resstock/Justfile` workflow for preparing a Switchbox `sb` ResStock release from the standard NREL release. The current end state is not just HP identification and non-HP approximation: the canonical flow also copies `metadata_utility`, runs multifamily electricity adjustment on the `sb` release for upgrades `00` and `02`, and syncs the finished `sb` release to EBS.
+This document outlines the current `data/resstock/Justfile` workflow for preparing a Switchbox `sb` ResStock release from the standard NREL release. The current end state is not just HP identification and non-HP approximation: the canonical flow also copies `metadata_utility`, runs multifamily electricity adjustment on the `sb` release for upgrades `00` and `02`, adds monthly load curves (aggregated from hourly) for gas/oil/propane billing, and syncs the finished `sb` release to EBS.
 
 All commands assume the project root as the current working directory unless noted. ResStock Justfile: `data/resstock/Justfile`. Default release names: standard `res_2024_amy2018_2`, sb release `res_2024_amy2018_2_sb`.
 
@@ -152,13 +152,61 @@ just -f data/resstock/Justfile adjust-mf-electricity <STATE> res_2024_amy2018_2 
 
 ## 7. Sync the finished sb release to EBS
 
-After approximation and multifamily-electricity adjustment, sync the finished `sb` release from S3 to local EBS so it is available for rate-design runs.
+After approximation and multifamily-electricity adjustment, sync the finished `sb` release from S3 to local EBS so it is available for rate-design runs and for building monthly load curves.
 
 ```bash
 sudo aws s3 sync s3://data.sb/nrel/resstock/res_2024_amy2018_2_sb/ /ebs/data/nrel/resstock/res_2024_amy2018_2_sb/
 ```
 
-- **Result:** Local path `/ebs/data/nrel/resstock/res_2024_amy2018_2_sb/` mirrors the sb release for use by CAIRO and other pipelines.
+- **Result:** Local path `/ebs/data/nrel/resstock/res_2024_amy2018_2_sb/` mirrors the sb release (including `load_curve_hourly`) for use by CAIRO and by step 8.
+
+---
+
+## 8. Add monthly load curves (EBS)
+
+Aggregate hourly load curves to monthly on local EBS (fast). Uses the same column-level aggregation rules as buildstock-fetch (sum for energy/emissions, mean for load/temperature). Output is written under `load_curve_monthly/state=<STATE>/upgrade=<ID>/` with one parquet per building (`{bldg_id}-{upgrade}.parquet`), consumed by gas/oil/propane bill logic in post-processing.
+
+**NY:**
+
+```bash
+just -f data/resstock/Justfile add-monthly-loads-NY
+```
+
+**RI:**
+
+```bash
+just -f data/resstock/Justfile add-monthly-loads RI "00 02"
+```
+
+**Generic:**
+
+```bash
+just -f data/resstock/Justfile add-monthly-loads <STATE> "<UPGRADE_IDS>"
+```
+
+- **Input:** `path_ebs_parquet` (default `/ebs/data/nrel/resstock/`) — expects `load_curve_hourly/state=<STATE>/upgrade=<ID>/` from step 7.
+- **Output:** `load_curve_monthly/state=<STATE>/upgrade=<ID>/` on EBS (12 rows per building, 140 columns).
+- **Result:** Local EBS has monthly load curves; upload to S3 in step 9 so the sb release on S3 is complete.
+
+---
+
+## 9. Upload monthly load curves to S3
+
+Sync the monthly load curves from EBS to S3 so the sb release on S3 includes `load_curve_monthly` for downstream (e.g. `build_master_bills`, gas/delivered-fuel bills).
+
+**NY:**
+
+```bash
+just -f data/resstock/Justfile upload-monthly-loads-NY
+```
+
+**Generic:**
+
+```bash
+just -f data/resstock/Justfile upload-monthly-loads <STATE> "<UPGRADE_IDS>"
+```
+
+- **Result:** `s3://data.sb/nrel/resstock/res_2024_amy2018_2_sb/load_curve_monthly/state=<STATE>/upgrade=<ID>/` is populated; the sb release on S3 is complete for rate-design and post-processing.
 
 ---
 
@@ -179,6 +227,8 @@ just -f data/resstock/Justfile create-sb-release-for-upgrade-02-NY
   - `adjust-mf-electricity-NY-upgrade-00`
   - `adjust-mf-electricity-NY-upgrade-02`
   - `sudo aws s3 sync ...`
+  - `add-monthly-loads-NY`
+  - `upload-monthly-loads-NY`
 
 **RI:**
 
@@ -193,6 +243,8 @@ just -f data/resstock/Justfile create-sb-release-for-upgrade-02-RI
   - `adjust-mf-electricity-RI-upgrade-00`
   - `adjust-mf-electricity-RI-upgrade-02`
   - `sudo aws s3 sync ...`
+  - `add-monthly-loads RI "00 02"`
+  - `upload-monthly-loads RI "00 02"`
 
 ---
 
@@ -207,5 +259,7 @@ just -f data/resstock/Justfile create-sb-release-for-upgrade-02-RI
 | 5    | `just -f data/resstock/Justfile approximate-non-hp-load <STATE> 02 res_2024_amy2018_2 res_2024_amy2018_2_sb 15 True True`                                                                                                 |
 | 6    | Adjust MF electricity in `sb`: `adjust-mf-electricity-<STATE>-upgrade-00` and `adjust-mf-electricity-<STATE>-upgrade-02`                                                                                                  |
 | 7    | `sudo aws s3 sync s3://data.sb/nrel/resstock/res_2024_amy2018_2_sb/ /ebs/data/nrel/resstock/res_2024_amy2018_2_sb/`                                                                                                       |
+| 8    | Add monthly load curves on EBS: `add-monthly-loads-NY` or `add-monthly-loads <STATE> "00 02"`                                                                                                                            |
+| 9    | Upload monthly load curves to S3: `upload-monthly-loads-NY` or `upload-monthly-loads <STATE> "00 02"`                                                                                                                     |
 
-After step 7, the `sb` release is ready for rate-design runs (e.g. CAIRO) using `res_2024_amy2018_2_sb` and the chosen state/upgrade.
+After step 9, the `sb` release on S3 and EBS includes `load_curve_monthly` and is ready for rate-design runs (e.g. CAIRO) and post-processing (master bills, gas/oil/propane bills) using `res_2024_amy2018_2_sb` and the chosen state/upgrade.

--- a/data/resstock/Justfile
+++ b/data/resstock/Justfile
@@ -258,6 +258,33 @@ adjust-mf-electricity-RI-upgrade-00:
 adjust-mf-electricity-RI-upgrade-02:
     just adjust-mf-electricity RI res_2024_amy2018_2 res_2024_amy2018_2_sb "02"
 
+path_ebs_parquet := "/ebs/data/nrel/resstock"
+
+add-monthly-loads state upgrade_ids:
+    uv run python "{{ path_local_repo }}/data/resstock/add_monthly_loads.py" \
+        --path-input "{{ path_ebs_parquet }}/{{ resstock_release_sb }}" \
+        --path-output "{{ path_ebs_parquet }}/{{ resstock_release_sb }}" \
+        --state "{{ state }}" \
+        --upgrade-ids "{{ upgrade_ids }}" \
+        --bsf-release "{{ resstock_release }}" \
+        --workers 50
+
+add-monthly-loads-NY:
+    just add-monthly-loads NY "00 02"
+
+upload-monthly-loads state upgrade_ids:
+    #!/usr/bin/env bash
+    set -e
+    for upgrade_id in {{ upgrade_ids }}; do
+        echo "Uploading load_curve_monthly/state={{ state }}/upgrade=$upgrade_id to S3..."
+        aws s3 sync \
+            "{{ path_ebs_parquet }}/{{ resstock_release_sb }}/load_curve_monthly/state={{ state }}/upgrade=$upgrade_id/" \
+            "{{ path_s3_parquet }}/{{ resstock_release_sb }}/load_curve_monthly/state={{ state }}/upgrade=$upgrade_id/"
+    done
+
+upload-monthly-loads-NY:
+    just upload-monthly-loads NY "00 02"
+
 create-sb-release-for-upgrade-02-NY:
     just prepare-metadata-ny lmi="true"
     just copy-resstock-data-2024-amy2018-2-NY "00 02" "metadata metadata_utility load_curve_hourly" # Copy data to new sb release
@@ -265,6 +292,8 @@ create-sb-release-for-upgrade-02-NY:
     just adjust-mf-electricity-NY-upgrade-00
     just adjust-mf-electricity-NY-upgrade-02
     sudo aws s3 sync s3://data.sb/nrel/resstock/res_2024_amy2018_2_sb/ /ebs/data/nrel/resstock/res_2024_amy2018_2_sb/
+    just add-monthly-loads-NY
+    just upload-monthly-loads-NY
 
 create-sb-release-for-upgrade-02-RI:
     just prepare-metadata-ri
@@ -273,3 +302,5 @@ create-sb-release-for-upgrade-02-RI:
     just adjust-mf-electricity-RI-upgrade-00
     just adjust-mf-electricity-RI-upgrade-02
     sudo aws s3 sync s3://data.sb/nrel/resstock/res_2024_amy2018_2_sb/ /ebs/data/nrel/resstock/res_2024_amy2018_2_sb/
+    just add-monthly-loads RI "00 02"
+    just upload-monthly-loads RI "00 02"

--- a/data/resstock/add_monthly_loads.py
+++ b/data/resstock/add_monthly_loads.py
@@ -1,0 +1,209 @@
+"""Aggregate hourly ResStock load curves into monthly load curves.
+
+Reads per-building hourly parquet files, aggregates to monthly using the same
+column-level rules as buildstock-fetch (sum for energy/emissions, mean for
+load/temperature), and writes one monthly parquet per building.
+
+Usage (from project root):
+    uv run python data/resstock/add_monthly_loads.py \
+        --path-input /ebs/data/nrel/resstock/res_2024_amy2018_2_sb \
+        --path-output /ebs/data/nrel/resstock/res_2024_amy2018_2_sb \
+        --state NY --upgrade-ids "00 02" \
+        --bsf-release res_2024_amy2018_2 --workers 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import cast
+
+import polars as pl
+
+from buildstock_fetch.constants import LOAD_CURVE_COLUMN_AGGREGATION
+
+
+def load_aggregation_rules(release: str) -> list[pl.Expr]:
+    """Build polars aggregation expressions from bsf's column map CSV."""
+    csv_path = LOAD_CURVE_COLUMN_AGGREGATION / f"{release}.csv"
+    if not csv_path.exists():
+        raise FileNotFoundError(
+            f"bsf column map not found: {csv_path}. "
+            f"Available: {[p.stem for p in LOAD_CURVE_COLUMN_AGGREGATION.glob('*.csv')]}"
+        )
+    rules_df = pl.read_csv(csv_path)
+    rules = dict(
+        zip(
+            rules_df["name"].to_list(),
+            rules_df["Aggregate_function"].to_list(),
+            strict=True,
+        )
+    )
+
+    exprs: list[pl.Expr] = []
+    for col, agg in rules.items():
+        if col == "timestamp":
+            continue
+        match agg:
+            case "sum":
+                exprs.append(pl.col(col).sum())
+            case "mean":
+                exprs.append(pl.col(col).mean())
+            case "first":
+                exprs.append(pl.col(col).first())
+            case _:
+                raise ValueError(f"Unknown aggregation function '{agg}' for column '{col}'")
+    return exprs
+
+
+def aggregate_one_building(
+    input_path: Path,
+    output_path: Path,
+    agg_rules: list[pl.Expr],
+) -> None:
+    """Read one hourly parquet, aggregate to monthly, write output."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # bsf's column map covers out.* and bldg_id but not year/day/hour/timestamp
+    # (those are added by bsf after aggregation). We add year.first() here and
+    # reconstruct timestamp from the result.
+    all_rules = [*agg_rules, pl.col("year").first()]
+
+    df = cast(
+        pl.DataFrame,
+        pl.scan_parquet(input_path)
+        .group_by("month")
+        .agg(all_rules)
+        .sort("month")
+        .collect(),
+    )
+
+    year = df["year"][0]
+
+    df = df.with_columns(
+        pl.datetime(year=year, month=pl.col("month"), day=1).alias("timestamp"),
+        pl.col("year").cast(pl.Int32),
+        pl.col("month").cast(pl.Int8),
+    )
+
+    out_cols = [c for c in df.columns if c.startswith("out.")]
+    col_order = ["timestamp", *out_cols, "bldg_id", "year", "month"]
+    df = df.select(col_order)
+
+    df.write_parquet(output_path)
+
+
+def process_upgrade(
+    path_input: Path,
+    path_output: Path,
+    state: str,
+    upgrade: str,
+    agg_rules: list[pl.Expr],
+    workers: int,
+) -> None:
+    """Process all building files for one upgrade."""
+    input_dir = path_input / f"load_curve_hourly/state={state}/upgrade={upgrade}"
+    output_dir = path_output / f"load_curve_monthly/state={state}/upgrade={upgrade}"
+
+    if not input_dir.exists():
+        print(f"  Input directory does not exist, skipping: {input_dir}")
+        return
+
+    files = sorted(input_dir.glob("*.parquet"))
+    n_files = len(files)
+    if n_files == 0:
+        print(f"  No parquet files found in {input_dir}")
+        return
+
+    print(f"  Found {n_files:,} hourly files in {input_dir}")
+    print(f"  Output: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    t0 = time.time()
+    done = 0
+    errors = 0
+
+    def _process(src: Path) -> str | None:
+        dst = output_dir / src.name
+        try:
+            aggregate_one_building(src, dst, agg_rules)
+            return None
+        except Exception as e:
+            return f"{src.name}: {e}"
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(_process, f): f for f in files}
+        for future in as_completed(futures):
+            result = future.result()
+            done += 1
+            if result is not None:
+                errors += 1
+                print(f"  ERROR {result}")
+            if done % 5000 == 0 or done == n_files:
+                elapsed = time.time() - t0
+                rate = done / elapsed if elapsed > 0 else 0
+                print(f"  {done:,}/{n_files:,} ({rate:.0f} files/s, {elapsed:.1f}s elapsed)")
+
+    elapsed = time.time() - t0
+    print(f"  Done: {done:,} files in {elapsed:.1f}s ({errors} errors)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Aggregate hourly ResStock load curves to monthly."
+    )
+    parser.add_argument(
+        "--path-input",
+        required=True,
+        help="Root of the ResStock release (local), e.g. /ebs/data/nrel/resstock/res_2024_amy2018_2_sb",
+    )
+    parser.add_argument(
+        "--path-output",
+        required=True,
+        help="Root to write monthly load curves into (local), e.g. /ebs/data/nrel/resstock/res_2024_amy2018_2_sb",
+    )
+    parser.add_argument("--state", required=True, help="Two-letter state code, e.g. NY")
+    parser.add_argument(
+        "--upgrade-ids",
+        required=True,
+        help='Space-separated upgrade IDs, e.g. "00 02"',
+    )
+    parser.add_argument(
+        "--bsf-release",
+        required=True,
+        help="bsf release key for column aggregation rules, e.g. res_2024_amy2018_2",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=50,
+        help="Number of parallel workers (default: 50)",
+    )
+    args = parser.parse_args()
+
+    path_input = Path(args.path_input)
+    path_output = Path(args.path_output)
+    upgrade_ids = args.upgrade_ids.split()
+
+    if not path_input.exists():
+        print(f"Error: input path does not exist: {path_input}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Loading bsf aggregation rules for release '{args.bsf_release}'...")
+    agg_rules = load_aggregation_rules(args.bsf_release)
+    print(f"  {len(agg_rules)} column rules loaded")
+
+    for upgrade in upgrade_ids:
+        print(f"\n{'='*60}")
+        print(f"Processing state={args.state}, upgrade={upgrade}")
+        print(f"{'='*60}")
+        process_upgrade(path_input, path_output, args.state, upgrade, agg_rules, args.workers)
+
+    print("\nAll done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds `data/resstock/add_monthly_loads.py` to aggregate hourly per-building parquet files into monthly ones, using the same column-level aggregation rules as buildstock-fetch (sum for energy/emissions columns, mean for load-delivery and temperature columns). Output mirrors the `load_curve_hourly` file layout — one parquet per building `{bldg_id}-{upgrade}.parquet` under `load_curve_monthly/state=NY/upgrade={id}/` — so all existing downstream consumers (`gas_bills.py`, `delivered_fuel_bills.py`, `build_master_bills.py`) pick them up without changes.

**Key implementation notes:**

- Aggregation is done from the already-hourly `_sb` data on EBS (not from 15-min source), so the bsf −15-minute timestamp shift is not applied; the existing `month` column (Int8) on each hourly file is used as the group key directly.
- `--bsf-release` passes the base release name (`res_2024_amy2018_2`) to look up the bsf column-map CSV; the `_sb` path is expressed separately via `--path-input`/`--path-output`.
- Runs at ~85–90 files/s with 50 workers on EBS local disk (~7 min per upgrade vs >1 hr against S3).
- The Justfile's `path_ebs_parquet` variable (`/ebs/data/nrel/resstock`) is used rather than the existing `path_local_parquet` (which points at the s3fs FUSE mount).

Data is live on S3 at `s3://data.sb/nrel/resstock/res_2024_amy2018_2_sb/load_curve_monthly/state=NY/upgrade=00/` and `upgrade=02/` (33,790 files each).

Closes #357

Made with [Cursor](https://cursor.com)