### PR TITLE
Add fair-default rate design pipeline for NY

### DIFF
--- a/tests/test_compute_fair_default_feasible_line.py
+++ b/tests/test_compute_fair_default_feasible_line.py
@@ -187,14 +187,27 @@ def test_compute_revenue_sufficient_line_sweeps_winter_rate(
     assert isinstance(data, RevenueSufficientLineData)
 
     baseline_winter_rate = data.base_flat_rate
-    baseline_summer_rate = data.summer_rate_at(baseline_winter_rate)
+    baseline_summer_rate = data.summer_rate_at(
+        winter_rate=baseline_winter_rate,
+        fixed_charge=data.base_fixed_charge,
+    )
     assert baseline_winter_rate == pytest.approx(_BASE_RATE)
     assert baseline_summer_rate == pytest.approx(_BASE_RATE)
-    assert data.subclass_cross_subsidy_at(baseline_winter_rate) == pytest.approx(150.0)
+    assert data.subclass_cross_subsidy_at(
+        winter_rate=baseline_winter_rate,
+        fixed_charge=data.base_fixed_charge,
+    ) == pytest.approx(150.0)
 
     winter_floor_rate = 0.0
-    summer_at_floor = data.summer_rate_at(winter_floor_rate)
+    summer_at_floor = data.summer_rate_at(
+        winter_rate=winter_floor_rate,
+        fixed_charge=data.base_fixed_charge,
+    )
     assert summer_at_floor == pytest.approx(0.75)
+    assert data.summer_rate_at(
+        winter_rate=winter_floor_rate,
+        fixed_charge=2 * data.base_fixed_charge,
+    ) == pytest.approx(0.654)
 
     class_bill_at_floor = seasonal_bill(
         data.inputs.class_totals,
@@ -203,9 +216,18 @@ def test_compute_revenue_sufficient_line_sweeps_winter_rate(
         summer_at_floor,
     )
     assert class_bill_at_floor == pytest.approx(data.inputs.class_totals.current_bill)
-    assert data.subclass_cross_subsidy_at(winter_floor_rate) == pytest.approx(50.0)
-    assert data.subclass_cross_subsidy_at(winter_floor_rate) < (
-        data.subclass_cross_subsidy_at(baseline_winter_rate)
+    assert data.subclass_cross_subsidy_at(
+        winter_rate=winter_floor_rate,
+        fixed_charge=data.base_fixed_charge,
+    ) == pytest.approx(50.0)
+    assert data.subclass_cross_subsidy_at(
+        winter_rate=winter_floor_rate,
+        fixed_charge=data.base_fixed_charge,
+    ) < (
+        data.subclass_cross_subsidy_at(
+            winter_rate=baseline_winter_rate,
+            fixed_charge=data.base_fixed_charge,
+        )
     )
 
 

--- a/utils/mid/compute_fair_default_inputs.py
+++ b/utils/mid/compute_fair_default_inputs.py
@@ -480,33 +480,78 @@ class FeasibleLineData:
 
 @dataclass(frozen=True, slots=True)
 class RevenueSufficientLineData:
-    """Revenue-sufficient seasonal-rate sweep at the baseline fixed charge."""
+    """Revenue-sufficient seasonal-rate sweep for one or more fixed charges."""
 
     title: str
-    r_sum: AffineLine
     base_fixed_charge: float
-    base_flat_rate: float
     winter_rate_min: float
-    winter_rate_max: float
+    feasible_min_fixed_charge: float
+    feasible_min_exists: bool
     inputs: FairDefaultInputs
 
-    def summer_rate_at(self, winter_rate: float) -> float:
-        """Return the C1-implied summer rate for a winter-rate choice."""
-        return self.r_sum.at(winter_rate)
+    @property
+    def base_flat_rate(self) -> float:
+        """Return the revenue-sufficient flat rate at the calibrated fixed charge."""
+        return self.flat_rate_at(self.base_fixed_charge)
 
-    def subclass_cross_subsidy_at(self, winter_rate: float) -> float:
-        """Return weighted subclass cross-subsidy at a winter-rate choice."""
-        return subclass_cross_subsidy_at(
-            self.inputs,
-            self.base_fixed_charge,
-            winter_rate,
-            self.summer_rate_at(winter_rate),
+    @property
+    def winter_rate_max(self) -> float:
+        """Return the baseline winter-rate sweep maximum for legacy callers."""
+        return self.base_flat_rate
+
+    def flat_rate_at(self, fixed_charge: float) -> float:
+        """Return the C1-implied flat volumetric rate at a fixed charge."""
+        return energy_revenue(self.inputs.class_totals, fixed_charge) / (
+            self.inputs.class_totals.annual_kwh
         )
 
-    def subclass_cross_subsidy_per_customer_at(self, winter_rate: float) -> float:
+    def summer_rate_line_at(self, fixed_charge: float) -> AffineLine:
+        """Return summer-rate line as a function of winter rate at fixed charge."""
+        class_totals = self.inputs.class_totals
+        _require_nonzero(class_totals.summer_kwh, "class summer kWh")
+        class_energy_target = energy_revenue(class_totals, fixed_charge)
+        return AffineLine(
+            intercept=class_energy_target / class_totals.summer_kwh,
+            slope=-class_totals.winter_kwh / class_totals.summer_kwh,
+        )
+
+    def summer_rate_at(
+        self,
+        winter_rate: float,
+        *,
+        fixed_charge: float | None = None,
+    ) -> float:
+        """Return the C1-implied summer rate for a winter-rate choice."""
+        fixed_charge = self.base_fixed_charge if fixed_charge is None else fixed_charge
+        return self.summer_rate_line_at(fixed_charge).at(winter_rate)
+
+    def subclass_cross_subsidy_at(
+        self,
+        winter_rate: float,
+        *,
+        fixed_charge: float | None = None,
+    ) -> float:
+        """Return weighted subclass cross-subsidy at a winter-rate choice."""
+        fixed_charge = self.base_fixed_charge if fixed_charge is None else fixed_charge
+        return subclass_cross_subsidy_at(
+            self.inputs,
+            fixed_charge,
+            winter_rate,
+            self.summer_rate_at(winter_rate, fixed_charge=fixed_charge),
+        )
+
+    def subclass_cross_subsidy_per_customer_at(
+        self,
+        winter_rate: float,
+        *,
+        fixed_charge: float | None = None,
+    ) -> float:
         """Return per-customer subclass cross-subsidy at a winter-rate choice."""
         return (
-            self.subclass_cross_subsidy_at(winter_rate)
+            self.subclass_cross_subsidy_at(
+                winter_rate,
+                fixed_charge=fixed_charge,
+            )
             / self.inputs.subclass_totals.customer_count
         )
 
@@ -684,21 +729,16 @@ def _build_revenue_sufficient_line_data(
     inputs: FairDefaultInputs,
     title: str,
 ) -> RevenueSufficientLineData:
-    """Build the C1-only seasonal sweep at the baseline fixed charge."""
-    class_totals = inputs.class_totals
-    _require_nonzero(class_totals.summer_kwh, "class summer kWh")
-
-    class_energy_target = energy_revenue(class_totals, inputs.base_fixed_charge)
-    slope = -class_totals.winter_kwh / class_totals.summer_kwh
-    intercept = class_energy_target / class_totals.summer_kwh
+    """Build the C1-only seasonal sweep helper."""
+    _require_nonzero(inputs.class_totals.summer_kwh, "class summer kWh")
+    feasibility = fixed_charge_feasibility(inputs)
 
     return RevenueSufficientLineData(
         title=title,
-        r_sum=AffineLine(intercept=intercept, slope=slope),
         base_fixed_charge=inputs.base_fixed_charge,
-        base_flat_rate=inputs.base_flat_rate,
         winter_rate_min=0.0,
-        winter_rate_max=inputs.base_flat_rate,
+        feasible_min_fixed_charge=feasibility.minimum,
+        feasible_min_exists=feasibility.exists,
         inputs=inputs,
     )
 


### PR DESCRIPTION
## Summary

This PR delivers the full fair-default rate design pipeline for NY — the modules, configs, tariff artifacts, tests, and orchestration scaffolding needed to run the three closed-form fair-default strategies (A: `fixed_charge_only`, B: `seasonal_rates_only`, C: `fixed_plus_seasonal_mc`) across all six NY utilities.

**Key deliverables:**

- `utils/mid/compute_fair_default_inputs.py` — computes class and HP subclass aggregate inputs (kWh by season, bills, cross-subsidy) from CAIRO baseline outputs
- `utils/mid/create_fair_default_tariff.py` — closed-form solver for strategies A/B/C via Cramer's rule; returns a modified URDB tariff JSON
- `utils/mid/prepare_fair_default_tariffs.py` — orchestration layer that runs strategies across all utilities in a batch
- `utils/pre/create_fair_default_scenario_yamls.py` — generates per-utility fair-default scenario YAMLs (runs 101–124)
- Generalised feasible-line geometry: revenue-sufficiency and cross-subsidy-zero lines in (F, r_sum) space, including revenue-sufficient line for arbitrary seasonal rate combos and cross-subsidy calcs across all seasonal rate combinations
- NY fair-default tariff configs: URDB JSONs, tariff maps, scenario YAMLs, and calibrated tariff JSONs for all six NY utilities (CenHud, ConEd, NIMO, NYSEG, O&R, RGE)
- `utils/pre/compute_tou.py` — demand-weighted rho_MC input for strategy C
- Extended `validate_config.py` to require `bulk_tx` entry in marginal-cost configs
- Context doc: `context/methods/tou_and_rates/fair_default_rate_design.md` — full math derivation, closed-form strategies, feasibility geometry
- Tests: `test_compute_fair_default_inputs.py`, `test_create_fair_default_tariff.py`, `test_compute_fair_default_feasible_line.py`, `test_compute_tou.py`
- `.gitignore`: added `.tmp/` for local pytest basetemp
- Removed `utils/mid/plot_feasible_line.py` (plotting migrated to reports2)

Closes #398

## Reviewer focus

- **Strategy math**: `create_fair_default_tariff.py` implements a 2×2 Cramer's-rule solve for each strategy — worth a close read to confirm the linear system is assembled correctly relative to the notation in `context/methods/tou_and_rates/fair_default_rate_design.md`.
- **Feasible-line generalisation**: `1a57bfc` and `f7d9c02` extend the feasible-line computation to work across arbitrary seasonal rate combinations, not just the (F, r_sum) plane — verify the parameterisation matches the math doc.
- **Config artifacts**: the NY utility URDB JSONs, tariff maps, and scenario YAMLs were hand-assembled and then validated by `validate_config.py`; spot-check NYSEG and RGE since they have the most complex gas/seasonal structures.

## Non-obvious implementation details

- Strategy C slaves the winter rate to the summer rate via `rho_MC = kWh_win_hp / kWh_sum_hp` (demand-weighted, not MC-weighted — see `compute_tou.py`), which keeps the seasonal differential cost-reflective without requiring a separate MC time-series input at tariff-solve time.
- The `prepare_fair_default_tariffs.py` orchestration layer is intentionally thin: it calls `compute_fair_default_inputs` → `create_fair_default_tariff` per utility per strategy and writes calibrated JSONs back into `config/tariffs/electric/`, matching the same promotion pattern used by the seasonal-discount workflow.
- Plotting of the feasible line was removed from this repo (commit `ad6208c`) because it lives in reports2's `fair_default_feasible_line.qmd` notebook — keeping visualisation out of the platform keeps the dependency boundary clean.