### PR TITLE
Disable PackageKit auto-reboot on EC2 dev instances

### DIFF
--- a/infra/user-data.sh
+++ b/infra/user-data.sh
@@ -322,6 +322,16 @@ sed -i 's/^#\?ClientAliveInterval.*/ClientAliveInterval 60/' /etc/ssh/sshd_confi
 sed -i 's/^#\?ClientAliveCountMax.*/ClientAliveCountMax 10/' /etc/ssh/sshd_config
 systemctl reload sshd || systemctl reload ssh || true
 
+# Disable PackageKit offline-update and unattended-upgrades auto-reboot.
+# On a dev EC2 instance, automatic OS-update reboots break open IDE sessions
+# (Cursor/VS Code SSH) without warning. We keep unattended-upgrades for
+# security patches but disable the automatic reboot trigger so updates are
+# applied at a time we choose (e.g. before starting a work session).
+systemctl mask packagekit-offline-update.service packagekit-trigger-offline-update.service 2>/dev/null || true
+systemctl disable --now packagekit.service 2>/dev/null || true
+sed -i 's|^//\(Unattended-Upgrade::Automatic-Reboot\) "false";|\1 "false";|' /etc/apt/apt.conf.d/50unattended-upgrades
+sed -i 's|^Unattended-Upgrade::Automatic-Reboot "true";|Unattended-Upgrade::Automatic-Reboot "false";|' /etc/apt/apt.conf.d/50unattended-upgrades
+
 # Start and enable SSM agent (for AWS Systems Manager Session Manager)
 systemctl enable amazon-ssm-agent || true
 systemctl start amazon-ssm-agent || true


### PR DESCRIPTION
Automatic OS-update reboots triggered by PackageKit / unattended-upgrades break open Cursor and VS Code SSH sessions without warning — the instance disappears mid-session with no prompt to save work.

This PR disables the automatic reboot trigger while keeping security patches flowing via unattended-upgrades. Specifically:

- Masks `packagekit-offline-update.service` and `packagekit-trigger-offline-update.service` so they cannot fire automatically.
- Disables the PackageKit daemon itself on boot.
- Sets `Unattended-Upgrade::Automatic-Reboot "false"` in `/etc/apt/apt.conf.d/50unattended-upgrades` (handles both the default commented-out form and an explicit `"true"` override).

Security patches continue to download and stage; they are applied manually at the start of a work session via `sudo apt-get dist-upgrade`.

**Reviewer focus**: The two `sed` patterns cover the two common states of the unattended-upgrades config file — worth confirming both match the actual file on a fresh Ubuntu 22.04 instance if you have one handy.

Made with [Cursor](https://cursor.com)