### PR TITLE
Add NYISO supply ancillary MC generation capability

### DIFF
--- a/data/nyiso/ancillary/Justfile
+++ b/data/nyiso/ancillary/Justfile
@@ -1,0 +1,47 @@
+# NYISO ancillary service clearing prices (day-ahead hourly + real-time 5-min AS)
+#
+# Same recipe shape as data/isone/ancillary/Justfile: fetch, validate, prepare,
+# upload, update, clean. Default ``markets=rt`` (5-minute real-time)—finest MIS
+# resolution. Override: ``markets=dam`` (hourly day-ahead) or ``markets=both``.
+#
+# Run from repo root: just -f data/nyiso/ancillary/Justfile <recipe>
+# Or from this dir:   just <recipe>
+
+path_local_repo := `git rev-parse --show-toplevel`
+path_local_base := justfile_directory()
+path_local_parquet := path_local_base + "/parquet"
+
+# Mirror ISO-NE: s3://data.sb/isone/ancillary/ → s3://data.sb/nyiso/ancillary/
+
+path_s3_parquet := "s3://data.sb/nyiso/ancillary/"
+start := "2010-01"
+end := ""
+markets := "rt"
+
+fetch:
+    uv run python "{{ path_local_base }}/fetch_nyiso_as_prices_parquet.py" \
+        --start "{{ start }}" --end "{{ end }}" \
+        --path-local-parquet "{{ path_local_parquet }}" \
+        --markets "{{ markets }}"
+
+validate:
+    uv run python "{{ path_local_base }}/validate_nyiso_as_prices_parquet.py" \
+        --path-local-parquet "{{ path_local_parquet }}"
+
+prepare: fetch validate
+
+# Upload: syncs whatever is under parquet/ (resolution is determined at fetch time).
+upload:
+    aws s3 sync "{{ path_local_parquet }}/" "{{ path_s3_parquet }}" \
+        --exclude "*" --include "*.parquet"
+    @echo "Uploaded to {{ path_s3_parquet }}"
+
+update:
+    uv run python "{{ path_local_base }}/update_nyiso_as_prices_to_latest.py" \
+        --path-local-parquet "{{ path_local_parquet }}" \
+        --path-s3-parquet "{{ path_s3_parquet }}" \
+        --markets "{{ markets }}"
+
+clean:
+    rm -rf "{{ path_local_parquet }}"
+    @echo "Removed parquet/"

--- a/data/nyiso/ancillary/fetch_nyiso_as_prices_parquet.py
+++ b/data/nyiso/ancillary/fetch_nyiso_as_prices_parquet.py
@@ -1,0 +1,682 @@
+#!/usr/bin/env python3
+"""Fetch NYISO ancillary service clearing prices via gridstatus → Hive-partitioned parquet.
+
+Uses ``NYISO._download_nyiso_archive`` with MIS datasets ``damasp`` (day-ahead hourly)
+and ``rtasp`` (real-time 5-minute) so **raw archive columns** are available. **Default**
+is ``rt`` only (5-minute rows)—the finest clearing-price resolution NYISO publishes in
+``rtasp``. Use ``--markets dam`` for hourly day-ahead only, or ``both`` for both.
+
+Historical MIS layouts (all normalized to the same output schema): **2010–2015** hub-wide
+East/West prices (no PTID); **2016-01–2016-06-22** adds SENY and zonal columns; **2016-06**
+also has a mid-month switch to zonal ``Name``/``PTID`` rows; **2016-07+** zonal only.
+Duplicate CSV headers are coalesced (common in 2016 hybrid zips).
+
+The public
+``get_as_prices_*`` methods call ``_handle_as_prices``, which drops ``Time Zone``,
+``PTID``, and the full ``($/MWHr)`` / ``($/MW)`` column names; this pipeline avoids
+that path.
+
+Interval start/end are aligned to match ``gridstatus.NYISO._handle_as_prices`` (same
+as ``get_as_prices_*``).
+
+Parquet uses snake_case names; MIS CSV equivalents:
+
+    time_zone                         ← Time Zone
+    zone                              ← Name
+    ptid                              ← PTID
+    spin_10min_usd_per_mwhr           ← 10 Min Spinning Reserve ($/MWHr)
+    non_sync_10min_usd_per_mwhr       ← 10 Min Non-Synchronous Reserve ($/MWHr)
+    operating_30min_usd_per_mwhr      ← 30 Min Operating Reserve ($/MWHr)
+    nyca_regulation_capacity_usd_per_mwhr ← NYCA Regulation Capacity ($/MWHr)
+    nyca_regulation_movement_usd_per_mw   ← NYCA Regulation Movement ($/MW); null for DAM
+
+Writes:
+    <output_dir>/year={YYYY}/month={MM}/data.parquet
+
+Schema (wide: one row per interval × zone × market):
+    year, month, market, time_et, interval_start_et, interval_end_et,
+    zone, time_zone, ptid,
+    spin_10min_usd_per_mwhr, non_sync_10min_usd_per_mwhr,
+    operating_30min_usd_per_mwhr, nyca_regulation_capacity_usd_per_mwhr,
+    nyca_regulation_movement_usd_per_mw
+
+Usage:
+    uv run python data/nyiso/ancillary/fetch_nyiso_as_prices_parquet.py \\
+        --start 2010-01 --end 2024-03 \\
+        --path-local-parquet data/nyiso/ancillary/parquet
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import time
+from collections.abc import Iterable
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+import polars as pl
+from gridstatus import NYISO
+
+# Raw MIS headers (post-``_handle_time`` inside ``_download_nyiso_archive``).
+_MIS_MOVEMENT = "NYCA Regulation Movement ($/MW)"
+
+_CANON_SPIN = "10 Min Spinning Reserve ($/MWHr)"
+_CANON_NONSYNC = "10 Min Non-Synchronous Reserve ($/MWHr)"
+_CANON_OPER = "30 Min Operating Reserve ($/MWHr)"
+_CANON_REGCAP = "NYCA Regulation Capacity ($/MWHr)"
+
+_MODERN_PRICE_COLS = (_CANON_SPIN, _CANON_NONSYNC, _CANON_OPER, _CANON_REGCAP)
+
+_INTERVAL_CORE = ("Time", "Interval Start", "Interval End")
+
+
+def parse_markets_cli(markets: str) -> frozenset[str]:
+    """Resolve ``--markets`` / Just ``markets=`` to a frozenset of ISO segments.
+
+    Default (finest resolution): ``rt`` (5-minute real-time). ``both`` → dam + rt.
+    """
+    raw = {x.strip().lower() for x in markets.split(",") if x.strip()}
+    if not raw:
+        return frozenset({"rt"})
+    if raw == {"both"}:
+        return frozenset({"dam", "rt"})
+    allowed = {"dam", "rt"}
+    bad = raw - allowed
+    if bad:
+        raise ValueError(f"unknown markets {bad}; use dam, rt, or both")
+    return frozenset(raw)
+
+
+def _reject_just_placeholders(val: str) -> None:
+    if "{{" in val or "}}" in val:
+        print(
+            f"ERROR: looks like an uninterpolated Just variable: {val}", file=sys.stderr
+        )
+        sys.exit(1)
+
+
+def _parse_month(s: str) -> tuple[int, int]:
+    parts = s.strip().split("-")
+    if len(parts) != 2:
+        raise ValueError(f"expected YYYY-MM, got {s!r}")
+    y, m = int(parts[0]), int(parts[1])
+    if not (1 <= m <= 12):
+        raise ValueError(f"invalid month in {s!r}")
+    return (y, m)
+
+
+def _month_range(start: tuple[int, int], end: tuple[int, int]) -> list[tuple[int, int]]:
+    out: list[tuple[int, int]] = []
+    y, m = start
+    while (y, m) <= end:
+        out.append((y, m))
+        if m == 12:
+            y, m = y + 1, 1
+        else:
+            m += 1
+    return out
+
+
+def _month_start_ts(iso: NYISO, year: int, month: int) -> pd.Timestamp:
+    return pd.Timestamp(year=year, month=month, day=1, tz=iso.default_timezone)
+
+
+def _month_end_exclusive_ts(iso: NYISO, year: int, month: int) -> pd.Timestamp:
+    if month == 12:
+        return pd.Timestamp(year=year + 1, month=1, day=1, tz=iso.default_timezone)
+    return pd.Timestamp(year=year, month=month + 1, day=1, tz=iso.default_timezone)
+
+
+def _apply_handle_as_prices_intervals(
+    pdf: pd.DataFrame, *, rt_or_dam: str
+) -> pd.DataFrame:
+    """Mirror ``NYISO._handle_as_prices`` interval adjustments only."""
+    df = pdf.copy()
+    if rt_or_dam == "rt":
+        df["Interval End"] = df["Interval Start"]
+        df["Interval Start"] = df["Interval Start"] - pd.Timedelta(minutes=5)
+    else:
+        df["Interval End"] = df["Interval Start"] + pd.Timedelta(minutes=60)
+    return df
+
+
+def _strip_column_names(pdf: pd.DataFrame) -> pd.DataFrame:
+    out = pdf.copy()
+    out.columns = [str(c).strip() for c in out.columns]
+    return out
+
+
+def _coerce_regulation_movement_column(pdf: pd.DataFrame) -> pd.DataFrame:
+    """Rename any MIS regulation-movement column to ``_MIS_MOVEMENT``."""
+    if _MIS_MOVEMENT in pdf.columns:
+        return pdf
+    for c in pdf.columns:
+        if "Regulation Movement" in c and "$/MW" in c:
+            return pdf.rename(columns={c: _MIS_MOVEMENT})
+    return pdf
+
+
+def _coalesce_duplicate_column_names(pdf: pd.DataFrame) -> pd.DataFrame:
+    """MIS CSVs sometimes repeat the same header twice; merge left-to-right with bfill."""
+    out = pdf.copy()
+    dup_names = out.columns[out.columns.duplicated(keep=False)].unique()
+    for name in dup_names:
+        mask = out.columns == name
+        block = out.loc[:, mask]
+        merged = block.bfill(axis=1).iloc[:, 0]
+        out = out.loc[:, ~mask]
+        out[name] = merged
+    return out
+
+
+def _is_modern_zonal_layout(columns: list[str]) -> bool:
+    return (
+        "Name" in columns
+        and "PTID" in columns
+        and _CANON_SPIN in columns
+        and _CANON_NONSYNC in columns
+        and _CANON_OPER in columns
+        and _CANON_REGCAP in columns
+    )
+
+
+def _legacy_wide_prefixes(columns: list[str]) -> list[tuple[str, str]]:
+    """Return (column prefix with trailing space, canonical zone label) pairs."""
+    out: list[tuple[str, str]] = []
+    if any(c.startswith("SENY ") for c in columns):
+        out.append(("SENY ", "SENY"))
+    if any(c.startswith("East ") for c in columns):
+        out.append(("East ", "EAST"))
+    if any(c.startswith("West ") for c in columns):
+        out.append(("West ", "WEST"))
+    return out
+
+
+def _find_zone_metric_columns(
+    columns: list[str], zone_prefix: str
+) -> dict[str, str | None]:
+    """Map logical metric → raw column name for one legacy hub (East/West/SENY)."""
+    spin = nonsync = oper = regcap = None
+    for c in columns:
+        if not c.startswith(zone_prefix):
+            continue
+        if "Movement" in c:
+            continue
+        if "10 Min Spinning" in c or ("Spinning" in c and "10" in c and "Reserve" in c):
+            spin = c
+        elif "Non-Synchronous" in c or "Non Synchronous" in c:
+            nonsync = c
+        elif "30 Min Operating" in c or ("Operating" in c and "30" in c):
+            oper = c
+        elif "Regulation" in c:
+            regcap = c
+    return {
+        "spin": spin,
+        "nonsync": nonsync,
+        "oper": oper,
+        "regcap": regcap,
+    }
+
+
+def _zone_metrics_non_null(zm: dict[str, str | None]) -> bool:
+    return any(zm[k] is not None for k in zm)
+
+
+def _infer_time_zone_abbrev(ts: pd.Timestamp) -> str:
+    if isinstance(ts, pd.Timestamp) and ts.tzinfo is not None:
+        return str(ts.strftime("%Z"))
+    return ""
+
+
+def _mis_extra_price_columns(columns: Iterable[str], consumed: set[str]) -> list[str]:
+    out: list[str] = []
+    for c in columns:
+        if c in consumed:
+            continue
+        if "($/MWHr)" in c or "($/MW)" in c or "($/MWH)" in c:
+            out.append(c)
+    return out
+
+
+def _mis_header_to_extra_snake(col: str) -> str:
+    base = col.strip()
+    for suf in (" ($/MWHr)", " ($/MW)", " ($/MWH)"):
+        if base.endswith(suf):
+            base = base[: -len(suf)]
+            break
+    slug = re.sub(r"[^A-Za-z0-9]+", "_", base).strip("_").lower()
+    if col.strip().endswith("($/MW)") and not col.strip().endswith("($/MWHr)"):
+        return f"{slug}_usd_per_mw"
+    return f"{slug}_usd_per_mwhr"
+
+
+def _legacy_east_west_to_canonical(
+    pdf: pd.DataFrame, *, market: str
+) -> tuple[pd.DataFrame, set[str]]:
+    """Explode legacy hub-wide columns into one row per (interval, hub zone)."""
+    cols = list(pdf.columns)
+    zones = _legacy_wide_prefixes(cols)
+    if not zones:
+        raise ValueError(
+            "NYISO AS archive: expected East/West (or SENY) hub columns; "
+            f"got columns {cols!r}",
+        )
+
+    consumed: set[str] = set(_INTERVAL_CORE)
+    movement_col: str | None = _MIS_MOVEMENT if _MIS_MOVEMENT in cols else None
+    if movement_col:
+        consumed.add(movement_col)
+    tz_col = "Time Zone" if "Time Zone" in cols else None
+    if tz_col:
+        consumed.add(tz_col)
+
+    zone_maps: dict[str, dict[str, str | None]] = {}
+    for zpref, _zlabel in zones:
+        zm = _find_zone_metric_columns(cols, zpref)
+        zone_maps[zpref] = zm
+        for _k, v in zm.items():
+            if v is not None:
+                consumed.add(v)
+
+    for c in _MODERN_PRICE_COLS:
+        if c in cols:
+            consumed.add(c)
+    for c in ("Name", "PTID"):
+        if c in cols:
+            consumed.add(c)
+
+    extras_src = _mis_extra_price_columns(cols, consumed)
+    for c in extras_src:
+        consumed.add(c)
+
+    records: list[dict[str, object]] = []
+
+    for idx in range(len(pdf)):
+        row = pdf.iloc[idx]
+        ts = row["Time"]
+        tz_val = row[tz_col] if tz_col else _infer_time_zone_abbrev(ts)
+        mov = (
+            row[movement_col] if market == "rt" and movement_col is not None else pd.NA
+        )
+        for zpref, zlabel in zones:
+            zm = zone_maps[zpref]
+            if not _zone_metrics_non_null(zm):
+                continue
+            rec: dict[str, object] = {
+                "Time": ts,
+                "Time Zone": tz_val,
+                "Name": zlabel,
+                "PTID": pd.NA,
+                _CANON_SPIN: row[zm["spin"]] if zm["spin"] is not None else pd.NA,
+                _CANON_NONSYNC: row[zm["nonsync"]]
+                if zm["nonsync"] is not None
+                else pd.NA,
+                _CANON_OPER: row[zm["oper"]] if zm["oper"] is not None else pd.NA,
+                _CANON_REGCAP: row[zm["regcap"]] if zm["regcap"] is not None else pd.NA,
+                _MIS_MOVEMENT: mov,
+                "Interval Start": row["Interval Start"],
+                "Interval End": row["Interval End"],
+            }
+            for xc in extras_src:
+                rec[xc] = row[xc]
+            records.append(rec)
+
+    out = pd.DataFrame.from_records(records)
+    return out, consumed
+
+
+def _consume_modern_layout_noise(columns: list[str]) -> set[str]:
+    """Columns present in hybrid months that we ignore when reading zonal rows."""
+    noise: set[str] = set()
+    for c in columns:
+        s = c.strip()
+        if s.startswith("East ") or s.startswith("West ") or s.startswith("SENY "):
+            noise.add(c)
+    return noise
+
+
+def _modern_to_canonical(
+    pdf: pd.DataFrame, *, market: str
+) -> tuple[pd.DataFrame, set[str]]:
+    """Subset modern MIS zonal layout to canonical column names (+ extras)."""
+    cols = list(pdf.columns)
+    need = [
+        "Time",
+        "Time Zone",
+        "Name",
+        "PTID",
+        _CANON_SPIN,
+        _CANON_NONSYNC,
+        _CANON_OPER,
+        _CANON_REGCAP,
+        "Interval Start",
+        "Interval End",
+    ]
+    missing = [c for c in need if c not in cols]
+    if missing:
+        raise ValueError(f"missing expected modern MIS columns: {missing}")
+
+    consumed = set(need)
+    consumed |= _consume_modern_layout_noise(cols)
+    if _MIS_MOVEMENT in cols:
+        consumed.add(_MIS_MOVEMENT)
+
+    extras_src = _mis_extra_price_columns(cols, consumed)
+    for c in extras_src:
+        consumed.add(c)
+
+    take = need.copy()
+    if _MIS_MOVEMENT in cols:
+        take.append(_MIS_MOVEMENT)
+    out = pdf[take + extras_src].copy()
+    if _MIS_MOVEMENT not in out.columns:
+        out[_MIS_MOVEMENT] = pd.NA
+    if market != "rt":
+        out[_MIS_MOVEMENT] = pd.NA
+    return out, consumed
+
+
+def _normalize_nyiso_as_archive_pdf(pdf: pd.DataFrame, *, market: str) -> pd.DataFrame:
+    """Map historical MIS shapes (hub-wide, hybrid, zonal) to one canonical wide schema."""
+    pdf = _strip_column_names(pdf)
+    pdf = _coerce_regulation_movement_column(pdf)
+    pdf = _coalesce_duplicate_column_names(pdf)
+    cols = list(pdf.columns)
+
+    if _is_modern_zonal_layout(cols):
+        has_name = "Name" in pdf.columns
+        if has_name and pdf["Name"].notna().any() and pdf["Name"].isna().any():
+            leg = pdf[pdf["Name"].isna()].copy()
+            for drop_c in ("Name", "PTID"):
+                if drop_c in leg.columns:
+                    leg = leg.drop(columns=[drop_c])
+            mod = pdf[pdf["Name"].notna()].copy()
+            out_l, _ = _legacy_east_west_to_canonical(leg, market=market)
+            out_m, _ = _modern_to_canonical(mod, market=market)
+            combined = pd.concat([out_l, out_m], ignore_index=True, sort=False)
+            return combined.sort_values(
+                ["Interval Start", "Name"],
+                kind="mergesort",
+            )
+
+        if has_name and pdf["Name"].notna().all():
+            out, _ = _modern_to_canonical(pdf, market=market)
+            return out.sort_values(["Interval Start", "Name"], kind="mergesort")
+
+        leg_only = pdf.drop(columns=[c for c in ("Name", "PTID") if c in pdf.columns])
+        out, _ = _legacy_east_west_to_canonical(leg_only, market=market)
+        return out.sort_values(["Interval Start", "Name"], kind="mergesort")
+
+    out, _ = _legacy_east_west_to_canonical(pdf, market=market)
+    return out.sort_values(["Interval Start", "Name"], kind="mergesort")
+
+
+def _raw_archive_pdf_to_polars(
+    pdf: pd.DataFrame, *, market: str, year: int, month: int
+) -> pl.DataFrame:
+    """Wide rows: one row per (interval, zone) with all MIS-derived measures."""
+    pdf = _normalize_nyiso_as_archive_pdf(pdf, market=market)
+
+    required = [
+        "Time",
+        "Time Zone",
+        "Name",
+        "PTID",
+        _CANON_SPIN,
+        _CANON_NONSYNC,
+        _CANON_OPER,
+        _CANON_REGCAP,
+        "Interval Start",
+        "Interval End",
+    ]
+    missing = [c for c in required if c not in pdf.columns]
+    if missing:
+        raise ValueError(f"missing expected MIS columns after normalize: {missing}")
+
+    pdf = _apply_handle_as_prices_intervals(
+        pdf, rt_or_dam="rt" if market == "rt" else "dam"
+    )
+    if _MIS_MOVEMENT not in pdf.columns:
+        pdf[_MIS_MOVEMENT] = pd.NA
+
+    core_exprs = [
+        pl.col("Time").cast(pl.Datetime("us", "America/New_York")).alias("time_et"),
+        pl.col("Interval Start")
+        .cast(pl.Datetime("us", "America/New_York"))
+        .alias("interval_start_et"),
+        pl.col("Interval End")
+        .cast(pl.Datetime("us", "America/New_York"))
+        .alias("interval_end_et"),
+        pl.col("Time Zone").cast(pl.String).alias("time_zone"),
+        pl.col("Name").cast(pl.String).alias("zone"),
+        pl.col("PTID").cast(pl.Int64).alias("ptid"),
+        pl.col(_CANON_SPIN).cast(pl.Float64).alias("spin_10min_usd_per_mwhr"),
+        pl.col(_CANON_NONSYNC).cast(pl.Float64).alias("non_sync_10min_usd_per_mwhr"),
+        pl.col(_CANON_OPER).cast(pl.Float64).alias("operating_30min_usd_per_mwhr"),
+        pl.col(_CANON_REGCAP)
+        .cast(pl.Float64)
+        .alias("nyca_regulation_capacity_usd_per_mwhr"),
+        pl.col(_MIS_MOVEMENT)
+        .cast(pl.Float64)
+        .alias("nyca_regulation_movement_usd_per_mw"),
+    ]
+
+    plf = pl.from_pandas(pdf, nan_to_null=True)
+    extra_cols = [c for c in plf.columns if c not in required and c != _MIS_MOVEMENT]
+    extra_exprs = []
+    extra_snakes: list[str] = []
+    for c in sorted(extra_cols):
+        snake = _mis_header_to_extra_snake(c)
+        extra_snakes.append(snake)
+        extra_exprs.append(pl.col(c).cast(pl.Float64).alias(snake))
+
+    ordered = [
+        "year",
+        "month",
+        "market",
+        "time_et",
+        "interval_start_et",
+        "interval_end_et",
+        "time_zone",
+        "zone",
+        "ptid",
+        "spin_10min_usd_per_mwhr",
+        "non_sync_10min_usd_per_mwhr",
+        "operating_30min_usd_per_mwhr",
+        "nyca_regulation_capacity_usd_per_mwhr",
+        "nyca_regulation_movement_usd_per_mw",
+    ]
+
+    out = plf.select(
+        *core_exprs,
+        *extra_exprs,
+    ).with_columns(
+        pl.lit(market).cast(pl.Categorical).alias("market"),
+        pl.lit(year).cast(pl.Int16).alias("year"),
+        pl.lit(month).cast(pl.UInt8).alias("month"),
+    )
+    tail = sorted(extra_snakes)
+    return out.select([*ordered, *tail]).sort(
+        "market",
+        "interval_start_et",
+        "zone",
+    )
+
+
+def fetch_as_month(
+    iso: NYISO,
+    year: int,
+    month: int,
+    *,
+    markets: frozenset[str],
+) -> pl.DataFrame | None:
+    """Fetch one calendar month via archive download (preserves MIS columns)."""
+    start_ts = _month_start_ts(iso, year, month)
+    end_ts = _month_end_exclusive_ts(iso, year, month)
+    frames: list[pl.DataFrame] = []
+
+    if "dam" in markets:
+        try:
+            pdf = iso._download_nyiso_archive(
+                date=start_ts,
+                end=end_ts,
+                dataset_name="damasp",
+                verbose=False,
+            )
+        except Exception as e:
+            print(f"    dam: error {e!s}")
+            pdf = pd.DataFrame()
+        if pdf is not None and len(pdf) > 0:
+            frames.append(
+                _raw_archive_pdf_to_polars(pdf, market="dam", year=year, month=month)
+            )
+
+    if "rt" in markets:
+        try:
+            pdf = iso._download_nyiso_archive(
+                date=start_ts,
+                end=end_ts,
+                dataset_name="rtasp",
+                verbose=False,
+            )
+        except Exception as e:
+            print(f"    rt: error {e!s}")
+            pdf = pd.DataFrame()
+        if pdf is not None and len(pdf) > 0:
+            frames.append(
+                _raw_archive_pdf_to_polars(pdf, market="rt", year=year, month=month)
+            )
+
+    if not frames:
+        return None
+    return pl.concat(frames, how="vertical")
+
+
+def _write_month_partition(df: pl.DataFrame, output_dir: Path) -> None:
+    y = int(df["year"][0])
+    m = int(df["month"][0])
+    part_dir = output_dir / f"year={y}" / f"month={m:02d}"
+    part_dir.mkdir(parents=True, exist_ok=True)
+    df.write_parquet(part_dir / "data.parquet", compression="snappy")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fetch NYISO AS prices via gridstatus archive → Hive-partitioned parquet",
+    )
+    parser.add_argument(
+        "--start",
+        type=str,
+        required=True,
+        help="First month (YYYY-MM)",
+    )
+    parser.add_argument(
+        "--end",
+        type=str,
+        default="",
+        help="Last month (YYYY-MM). Default: last complete calendar month.",
+    )
+    parser.add_argument(
+        "--path-local-parquet",
+        type=str,
+        required=True,
+        help="Output directory for Hive-partitioned parquet",
+    )
+    parser.add_argument(
+        "--markets",
+        type=str,
+        default="rt",
+        help="Comma-separated: rt (default, 5-min), dam (hourly), or both",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Re-fetch months even if data.parquet already exists (default: skip existing)",
+    )
+    parser.add_argument(
+        "--sleep-seconds",
+        type=float,
+        default=5.0,
+        help="Pause between months (default: 5)",
+    )
+    args = parser.parse_args()
+
+    _reject_just_placeholders(args.path_local_parquet)
+    output_dir = Path(args.path_local_parquet)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        markets = parse_markets_cli(args.markets)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    start_m = _parse_month(args.start)
+    if args.end:
+        end_m = _parse_month(args.end)
+    else:
+        today = datetime.now()
+        if today.month == 1:
+            end_m = (today.year - 1, 12)
+        else:
+            end_m = (today.year, today.month - 1)
+
+    months = _month_range(start_m, end_m)
+    if not months:
+        print("No months in range.")
+        return 0
+
+    to_fetch: list[tuple[int, int]] = []
+    for y, m in months:
+        part_file = output_dir / f"year={y}" / f"month={m:02d}" / "data.parquet"
+        if part_file.exists() and not args.overwrite:
+            continue
+        to_fetch.append((y, m))
+
+    if not to_fetch:
+        print("All partitions already exist. Nothing to fetch.")
+        return 0
+
+    print(f"Fetching {len(to_fetch)} months...")
+    iso = NYISO()
+    written = 0
+    failed = 0
+
+    for i, (y, m) in enumerate(to_fetch):
+        label = f"{y}-{m:02d}"
+        part_file = output_dir / f"year={y}" / f"month={m:02d}" / "data.parquet"
+        if i > 0 and args.sleep_seconds > 0:
+            print("  (cooling down {:.0f}s...)".format(args.sleep_seconds), flush=True)
+            time.sleep(args.sleep_seconds)
+
+        print(f"  {label}: fetching...", end=" ", flush=True)
+        df = fetch_as_month(iso, y, m, markets=markets)
+        if df is None:
+            print("no data")
+            failed += 1
+            continue
+
+        n_outside = df.filter(
+            (pl.col("interval_start_et").dt.year() != y)
+            | (pl.col("interval_start_et").dt.month() != m)
+        ).height
+        _write_month_partition(df, output_dir)
+        written += 1
+        print(f"{len(df)} rows")
+        if n_outside:
+            print(
+                f"  {label}: WARN {n_outside} rows with interval_start_et outside "
+                f"{y}-{m:02d} (ET)",
+                file=sys.stderr,
+            )
+
+    print(f"\nDone. {written} partitions written, {failed} months with no data.")
+    print(f"Output: {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/data/nyiso/ancillary/update_nyiso_as_prices_to_latest.py
+++ b/data/nyiso/ancillary/update_nyiso_as_prices_to_latest.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Discover latest NYISO AS price partition on disk or S3, fetch newer months.
+
+Lists local and S3 partitions under the given roots, takes the latest ``(year, month)``
+from their union, then fetches each subsequent month through the last complete month
+(same behavior as ``data/isone/ancillary/update_isone_ancillary_to_latest.py``).
+Does not upload (run ``just upload`` after).
+
+Default resolution matches fetch: **real-time (``rt``, 5-minute)** unless ``--markets``
+overrides (``dam`` / ``both``).
+
+Usage:
+    uv run python data/nyiso/ancillary/update_nyiso_as_prices_to_latest.py \\
+        --path-local-parquet data/nyiso/ancillary/parquet \\
+        --path-s3-parquet s3://data.sb/nyiso/ancillary/
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import polars as pl
+from gridstatus import NYISO
+
+from fetch_nyiso_as_prices_parquet import (
+    _write_month_partition,
+    fetch_as_month,
+    parse_markets_cli,
+)
+
+PARTITION_RE = re.compile(r"year=(\d{4})/month=(\d{1,2})")
+
+
+def _list_s3_partitions(prefix: str) -> list[tuple[int, int]]:
+    """List (year, month) partitions under an S3 prefix."""
+    result = subprocess.run(
+        ["aws", "s3", "ls", prefix.rstrip("/") + "/", "--recursive"],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    if result.returncode != 0:
+        return []
+    parts: set[tuple[int, int]] = set()
+    for line in result.stdout.splitlines():
+        for m in PARTITION_RE.finditer(line):
+            parts.add((int(m.group(1)), int(m.group(2))))
+    return sorted(parts)
+
+
+def _list_local_partitions(root: Path) -> list[tuple[int, int]]:
+    """List (year, month) partitions under a local directory."""
+    parts: set[tuple[int, int]] = set()
+    for f in root.glob("year=*/month=*/data.parquet"):
+        m = PARTITION_RE.search(str(f))
+        if m:
+            parts.add((int(m.group(1)), int(m.group(2))))
+    return sorted(parts)
+
+
+def _next_month(year: int, month: int) -> tuple[int, int]:
+    if month == 12:
+        return (year + 1, 1)
+    return (year, month + 1)
+
+
+def _last_complete_month() -> tuple[int, int]:
+    today = datetime.now()
+    if today.month == 1:
+        return (today.year - 1, 12)
+    return (today.year, today.month - 1)
+
+
+def _months_in_range(
+    start: tuple[int, int], end: tuple[int, int]
+) -> list[tuple[int, int]]:
+    months: list[tuple[int, int]] = []
+    current = start
+    while current <= end:
+        months.append(current)
+        current = _next_month(*current)
+    return months
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Update NYISO AS parquet: discover latest (local ∪ S3), fetch new months.",
+    )
+    parser.add_argument(
+        "--path-local-parquet",
+        type=str,
+        required=True,
+        help="Local parquet root for Hive-partitioned output",
+    )
+    parser.add_argument(
+        "--path-s3-parquet",
+        type=str,
+        required=True,
+        help="S3 prefix (e.g. s3://data.sb/nyiso/ancillary/)",
+    )
+    parser.add_argument(
+        "--markets",
+        type=str,
+        default="rt",
+        help="rt (default, 5-min), dam (hourly), or both",
+    )
+    args = parser.parse_args()
+
+    output_dir = Path(args.path_local_parquet)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        markets = parse_markets_cli(args.markets)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    local_parts = _list_local_partitions(output_dir)
+    s3_parts = _list_s3_partitions(args.path_s3_parquet)
+    all_parts = sorted(set(local_parts) | set(s3_parts))
+
+    if not all_parts:
+        print(
+            "No partitions found locally or on S3. Use `just fetch` for initial load.",
+            file=sys.stderr,
+        )
+        return 1
+
+    latest = max(all_parts)
+    start = _next_month(*latest)
+    end = _last_complete_month()
+
+    print(f"Latest partition: {latest[0]}-{latest[1]:02d}")
+    print(f"Target: through {end[0]}-{end[1]:02d}")
+
+    if start > end:
+        print(f"Already up to date through {end[0]}-{end[1]:02d}. Nothing to do.")
+        return 0
+
+    months_to_fetch = _months_in_range(start, end)
+    print(f"Months to fetch: {len(months_to_fetch)}")
+
+    iso = NYISO()
+    fetched: list[tuple[int, int]] = []
+
+    for year, month in months_to_fetch:
+        label = f"{year}-{month:02d}"
+        print(f"  {label}: fetching...", end=" ", flush=True)
+        df = fetch_as_month(iso, year, month, markets=markets)
+        if df is None:
+            print("no data — stopping")
+            break
+
+        _write_month_partition(df, output_dir)
+        part_file = output_dir / f"year={year}" / f"month={month:02d}" / "data.parquet"
+        n_rows = pl.read_parquet(part_file).height
+        print(f"{n_rows} rows")
+        fetched.append((year, month))
+
+    print(f"\nFetched {len(fetched)} new months")
+    if fetched:
+        first = fetched[0]
+        last = fetched[-1]
+        print(f"  {first[0]}-{first[1]:02d} through {last[0]}-{last[1]:02d}")
+        print("\nRun `just validate` then `just upload` when ready.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/data/nyiso/ancillary/validate_nyiso_as_prices_parquet.py
+++ b/data/nyiso/ancillary/validate_nyiso_as_prices_parquet.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Validate NYISO ancillary price parquet: schema, keys, prices, coarse row counts.
+
+Scans local Hive-partitioned parquet under ``path_local_parquet`` (``year=*/month=*/data.parquet``).
+Accepts any subset of ``market`` values (``dam`` and/or ``rt``); default fetches are
+``rt``-only (5-minute), so partitions may contain only ``market=rt``.
+
+Usage:
+    uv run python data/nyiso/ancillary/validate_nyiso_as_prices_parquet.py \\
+        --path-local-parquet data/nyiso/ancillary/parquet
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import polars as pl
+
+EXPECTED_MARKETS = {"dam", "rt"}
+
+# Pre-2017 MIS hub-wide rows use these zone labels with null PTID.
+_LEGACY_HUB_ZONES = frozenset({"EAST", "WEST", "SENY"})
+
+# RT ``NYCA Regulation Movement`` first appears in MIS archives in 2012-11.
+_MOVEMENT_REQUIRED_FROM: tuple[int, int] = (2012, 11)
+
+# Parquet dtypes; categoricals may round-trip as String in some readers — accept both.
+_SCHEMA_CORE_REQUIRED = {
+    "year": (pl.Int16,),
+    "month": (pl.UInt8,),
+    "market": (pl.Categorical, pl.String),
+    "time_et": (pl.Datetime("us", "America/New_York"),),
+    "interval_start_et": (pl.Datetime("us", "America/New_York"),),
+    "interval_end_et": (pl.Datetime("us", "America/New_York"),),
+    "time_zone": (pl.String,),
+    "zone": (pl.String,),
+    "ptid": (pl.Int64, pl.Int32),
+}
+
+# Standard NYISO AS price columns (present on typical MIS files); optional if ISO adds layout changes.
+_SCHEMA_KNOWN_FLOAT_OPTIONAL = {
+    "spin_10min_usd_per_mwhr": (pl.Float64,),
+    "non_sync_10min_usd_per_mwhr": (pl.Float64,),
+    "operating_30min_usd_per_mwhr": (pl.Float64,),
+    "nyca_regulation_capacity_usd_per_mwhr": (pl.Float64,),
+    "nyca_regulation_movement_usd_per_mw": (pl.Float64,),
+}
+
+_ALLOWED_EXTRA_DTYPES = (
+    pl.Float64,
+    pl.Float32,
+    pl.Int64,
+    pl.Int32,
+    pl.Int16,
+    pl.UInt8,
+    pl.UInt32,
+    pl.String,
+    pl.Utf8,
+    pl.Boolean,
+)
+
+_NON_NULL_CORE = [
+    "year",
+    "month",
+    "market",
+    "time_et",
+    "interval_start_et",
+    "interval_end_et",
+    "time_zone",
+    "zone",
+]
+
+# When these columns exist, require no nulls (DAM may omit movement; fetch backfills as null-only).
+_NON_NULL_FLOAT_IF_PRESENT = [
+    "spin_10min_usd_per_mwhr",
+    "non_sync_10min_usd_per_mwhr",
+    "operating_30min_usd_per_mwhr",
+    "nyca_regulation_capacity_usd_per_mwhr",
+]
+
+_FINITE_FLOAT_IF_PRESENT = [
+    "spin_10min_usd_per_mwhr",
+    "non_sync_10min_usd_per_mwhr",
+    "operating_30min_usd_per_mwhr",
+    "nyca_regulation_capacity_usd_per_mwhr",
+]
+
+
+def _collect_parquet_files(root: Path) -> list[Path]:
+    return sorted(root.glob("year=*/month=*/data.parquet"))
+
+
+def _check_file(path: Path) -> list[str]:
+    errors: list[str] = []
+    df = pl.read_parquet(path)
+    for col, allowed in _SCHEMA_CORE_REQUIRED.items():
+        if col not in df.columns:
+            errors.append(f"{path}: missing column {col}")
+            continue
+        if df.schema[col] not in allowed:
+            errors.append(
+                f"{path}: {col} expected one of {allowed}, got {df.schema[col]}",
+            )
+
+    for col, allowed in _SCHEMA_KNOWN_FLOAT_OPTIONAL.items():
+        if col not in df.columns:
+            continue
+        if df.schema[col] not in allowed:
+            errors.append(
+                f"{path}: {col} expected one of {allowed}, got {df.schema[col]}",
+            )
+
+    known_and_core = set(_SCHEMA_CORE_REQUIRED) | set(_SCHEMA_KNOWN_FLOAT_OPTIONAL)
+    for col in df.columns:
+        if col in known_and_core:
+            continue
+        if df.schema[col] not in _ALLOWED_EXTRA_DTYPES:
+            errors.append(
+                f"{path}: column {col!r} has unexpected dtype {df.schema[col]} "
+                f"(allowed extras: {_ALLOWED_EXTRA_DTYPES})",
+            )
+
+    if errors:
+        return errors
+
+    for col in _NON_NULL_CORE:
+        if df[col].null_count() > 0:
+            errors.append(f"{path}: nulls in required column {col}")
+
+    if "ptid" in df.columns:
+        bad_ptid = df.filter(
+            pl.col("ptid").is_null()
+            & ~pl.col("zone").cast(pl.String).is_in(list(_LEGACY_HUB_ZONES))
+        )
+        if bad_ptid.height > 0:
+            errors.append(
+                f"{path}: {bad_ptid.height} rows with null ptid outside legacy hubs "
+                f"{sorted(_LEGACY_HUB_ZONES)}",
+            )
+
+    for col in _NON_NULL_FLOAT_IF_PRESENT:
+        if col in df.columns and df[col].null_count() > 0:
+            errors.append(f"{path}: nulls in column {col}")
+
+    keys = ["interval_start_et", "interval_end_et", "zone", "market"]
+    n_dup = df.height - df.select(keys).unique().height
+    if n_dup:
+        errors.append(f"{path}: {n_dup} duplicate key rows")
+
+    for col in _FINITE_FLOAT_IF_PRESENT:
+        if col not in df.columns:
+            continue
+        n_bad = df.filter(pl.col(col).is_nan() | pl.col(col).is_infinite()).height
+        if n_bad:
+            errors.append(f"{path}: {n_bad} NaN/Inf in {col}")
+
+    mk = set(df["market"].cast(pl.String).unique().to_list())
+    if not mk <= EXPECTED_MARKETS:
+        errors.append(f"{path}: unexpected markets {mk - EXPECTED_MARKETS}")
+
+    for mkt in mk:
+        sub = df.filter(pl.col("market").cast(pl.String) == mkt)
+        n = sub.height
+        if mkt == "dam" and n < 24 * 10:
+            errors.append(f"{path}: dam rows suspiciously low ({n})")
+        if mkt == "rt" and n < 24 * 10 * 10:
+            errors.append(f"{path}: rt rows suspiciously low ({n})")
+
+    # DAM has no movement; RT MIS adds regulation movement from 2012-11 onward.
+    y = int(df["year"][0])
+    mo = int(df["month"][0])
+    rt = df.filter(pl.col("market").cast(pl.String) == "rt")
+    if rt.height > 0 and (y, mo) >= _MOVEMENT_REQUIRED_FROM:
+        if rt["nyca_regulation_movement_usd_per_mw"].null_count() == rt.height:
+            errors.append(f"{path}: all RT regulation movement values are null")
+
+    return errors
+
+
+def main() -> int:
+    import argparse
+
+    p = argparse.ArgumentParser(description="Validate NYISO AS price parquet")
+    p.add_argument(
+        "--path-local-parquet",
+        type=str,
+        required=True,
+        help="Hive-partitioned parquet root",
+    )
+    args = p.parse_args()
+    root = Path(args.path_local_parquet)
+    if not root.is_dir():
+        print(f"ERROR: not a directory: {root}", file=sys.stderr)
+        return 1
+
+    files = _collect_parquet_files(root)
+    if not files:
+        print(f"ERROR: no year=*/month=*/data.parquet under {root}", file=sys.stderr)
+        return 1
+
+    all_errors: list[str] = []
+    for f in files:
+        all_errors.extend(_check_file(f))
+
+    if all_errors:
+        for e in all_errors:
+            print(e, file=sys.stderr)
+        return 1
+
+    print(f"OK: {len(files)} partition file(s) under {root}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rate_design/hp_rates/ny/Justfile
+++ b/rate_design/hp_rates/ny/Justfile
@@ -82,6 +82,28 @@ create-supply_capacity-mc-data-all:
     just create-supply_capacity-mc-data rge
     just create-supply_capacity-mc-data psegli
 
+# NYISO ancillary clearing prices -> same Switchbox layout as energy/capacity
+# (s3://data.sb/switchbox/marginal_costs/ny/supply/ancillary/...). Raw inputs:
+# s3://data.sb/nyiso/ancillary/ (see data/nyiso/ancillary/ Justfile).
+# Opt-in: not part of create-supply-mc-data. To run NY with ancillary, generate
+# the parquet here, then set SUPPLY_ANCILLARY_MC before a supply run.
+
+create-supply-ancillary-mc-data utility_arg:
+    cd {{ project_root }} && uv run python {{ project_root }}/utils/data_prep/marginal_costs/generate_supply_ancillary_mc.py \
+      --iso nyiso \
+      --utility {{ utility_arg }} \
+      --year {{ supply_mc_year }} \
+      --upload
+
+create-supply-ancillary-mc-data-all:
+    just create-supply-ancillary-mc-data cenhud
+    just create-supply-ancillary-mc-data coned
+    just create-supply-ancillary-mc-data nimo
+    just create-supply-ancillary-mc-data nyseg
+    just create-supply-ancillary-mc-data or
+    just create-supply-ancillary-mc-data rge
+    just create-supply-ancillary-mc-data psegli
+
 # =============================================================================
 # NY-only: bulk transmission marginal costs (NYISO AC Tx / LI Export, SCR)
 # =============================================================================

--- a/tests/test_nyiso_as_prices_transform.py
+++ b/tests/test_nyiso_as_prices_transform.py
@@ -1,0 +1,160 @@
+"""Unit tests for NYISO AS raw-archive → Polars wide transform (no network)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+
+
+def _load_fetch_module():
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "data/nyiso/ancillary/fetch_nyiso_as_prices_parquet.py"
+    )
+    spec = importlib.util.spec_from_file_location("fetch_nyiso_as_prices_parquet", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_parse_markets_cli_defaults_to_rt() -> None:
+    mod = _load_fetch_module()
+    assert mod.parse_markets_cli("") == frozenset({"rt"})
+    assert mod.parse_markets_cli("rt") == frozenset({"rt"})
+    assert mod.parse_markets_cli("both") == frozenset({"dam", "rt"})
+    assert mod.parse_markets_cli("dam,rt") == frozenset({"dam", "rt"})
+
+
+def test_raw_archive_pdf_to_polars_wide_dam() -> None:
+    mod = _load_fetch_module()
+    ts = pd.Timestamp("2024-01-01 00:00:00", tz="America/New_York")
+    te = pd.Timestamp("2024-01-01 01:00:00", tz="America/New_York")
+    pdf = pd.DataFrame(
+        {
+            "Time": [ts],
+            "Time Zone": ["EST"],
+            "Name": ["WEST"],
+            "PTID": [61761],
+            "10 Min Spinning Reserve ($/MWHr)": [1.0],
+            "10 Min Non-Synchronous Reserve ($/MWHr)": [2.0],
+            "30 Min Operating Reserve ($/MWHr)": [3.0],
+            "NYCA Regulation Capacity ($/MWHr)": [4.0],
+            "Interval Start": [ts],
+            "Interval End": [te],
+        }
+    )
+    out = mod._raw_archive_pdf_to_polars(pdf, market="dam", year=2024, month=1)
+    assert out.height == 1
+    assert out["zone"].to_list() == ["WEST"]
+    assert out["ptid"].to_list() == [61761]
+    assert out["spin_10min_usd_per_mwhr"].to_list() == [1.0]
+    assert out["nyca_regulation_movement_usd_per_mw"].is_null().all()
+
+
+def test_raw_archive_pdf_to_polars_rt_interval_shift() -> None:
+    mod = _load_fetch_module()
+    ts = pd.Timestamp("2024-01-01 00:05:00", tz="America/New_York")
+    te = pd.Timestamp("2024-01-01 00:10:00", tz="America/New_York")
+    pdf = pd.DataFrame(
+        {
+            "Time": [ts],
+            "Time Zone": ["EST"],
+            "Name": ["WEST"],
+            "PTID": [61761],
+            "10 Min Spinning Reserve ($/MWHr)": [0.0],
+            "10 Min Non-Synchronous Reserve ($/MWHr)": [0.0],
+            "30 Min Operating Reserve ($/MWHr)": [0.0],
+            "NYCA Regulation Capacity ($/MWHr)": [6.0],
+            "NYCA Regulation Movement ($/MW)": [0.5],
+            "Interval Start": [ts],
+            "Interval End": [te],
+        }
+    )
+    out = mod._raw_archive_pdf_to_polars(pdf, market="rt", year=2024, month=1)
+    assert out.height == 1
+    # gridstatus RT: End <- old Start, Start <- old Start - 5 min
+    assert out["interval_end_et"].dt.strftime("%H:%M")[0] == "00:05"
+    assert out["interval_start_et"].dt.strftime("%H:%M")[0] == "00:00"
+    assert out["nyca_regulation_movement_usd_per_mw"].to_list() == [0.5]
+
+
+def test_legacy_east_west_wide_rt_to_polars() -> None:
+    """Pre-2016 hub-wide MIS columns (East/West) normalize to zonal long rows."""
+    mod = _load_fetch_module()
+    ts = pd.Timestamp("2015-01-01 00:05:00", tz="America/New_York")
+    te = pd.Timestamp("2015-01-01 00:10:00", tz="America/New_York")
+    pdf = pd.DataFrame(
+        {
+            "Time": [ts],
+            "East 10 Min Spinning Reserve ($/MWHr)": [1.0],
+            "East 10 Min Non-Synchronous Reserve": [2.0],
+            "East 30 Min Operating Reserve ($/MWH)": [3.0],
+            "East Regulation ($/MWHr)": [4.0],
+            "West 10 Min Spinning Reserve ($/MWHr)": [5.0],
+            "West 10 Min Non-Synchronous Reserve": [6.0],
+            "West 30 Min Operating Reserve ($/MWH)": [7.0],
+            "West Regulation ($/MWHr)": [8.0],
+            "NYCA Regulation Movement ($/MW)": [0.5],
+            "Interval Start": [ts],
+            "Interval End": [te],
+        }
+    )
+    out = mod._raw_archive_pdf_to_polars(pdf, market="rt", year=2015, month=1)
+    assert out.height == 2
+    assert set(out["zone"].to_list()) == {"EAST", "WEST"}
+    assert out["ptid"].null_count() == 2
+    assert out["spin_10min_usd_per_mwhr"].to_list() == [1.0, 5.0]
+    assert out["nyca_regulation_movement_usd_per_mw"].to_list() == [0.5, 0.5]
+
+
+def test_legacy_dam_truncated_paren_headers() -> None:
+    """DAM MIS sometimes omits the closing ``)`` on spinning-reserve headers."""
+    mod = _load_fetch_module()
+    ts = pd.Timestamp("2010-01-01 00:00:00", tz="America/New_York")
+    te = pd.Timestamp("2010-01-01 01:00:00", tz="America/New_York")
+    pdf = pd.DataFrame(
+        {
+            "Time": [ts],
+            "East 10 Min Spinning Reserve ($/MWHr": [1.0],
+            "East 10 Min Non-Synchronous Reserve": [2.0],
+            "East 30 Min Operating Reserve ($/MWH": [3.0],
+            "East Regulation ($/MWHr)": [4.0],
+            "West 10 Min Spinning Reserve ($/MWHr": [5.0],
+            "West 10 Min Non-Synchronous Reserve": [6.0],
+            "West 30 Min Operating Reserve ($/MWH": [7.0],
+            "West Regulation ($/MWHr)": [8.0],
+            "Interval Start": [ts],
+            "Interval End": [te],
+        }
+    )
+    out = mod._raw_archive_pdf_to_polars(pdf, market="dam", year=2010, month=1)
+    assert out.height == 2
+    assert out["nyca_regulation_movement_usd_per_mw"].is_null().all()
+
+
+def test_raw_archive_passes_through_unknown_mis_columns() -> None:
+    mod = _load_fetch_module()
+    ts = pd.Timestamp("2024-01-01 00:00:00", tz="America/New_York")
+    te = pd.Timestamp("2024-01-01 01:00:00", tz="America/New_York")
+    pdf = pd.DataFrame(
+        {
+            "Time": [ts],
+            "Time Zone": ["EST"],
+            "Name": ["WEST"],
+            "PTID": [61761],
+            "10 Min Spinning Reserve ($/MWHr)": [1.0],
+            "10 Min Non-Synchronous Reserve ($/MWHr)": [2.0],
+            "30 Min Operating Reserve ($/MWHr)": [3.0],
+            "NYCA Regulation Capacity ($/MWHr)": [4.0],
+            "Interval Start": [ts],
+            "Interval End": [te],
+            "Hypothetical New Product ($/MWHr)": [9.25],
+        }
+    )
+    out = mod._raw_archive_pdf_to_polars(pdf, market="dam", year=2024, month=1)
+    assert "hypothetical_new_product_usd_per_mwhr" in out.columns
+    assert out["hypothetical_new_product_usd_per_mwhr"].to_list() == [9.25]

--- a/tests/test_supply_ancillary_mc.py
+++ b/tests/test_supply_ancillary_mc.py
@@ -1,4 +1,4 @@
-"""Tests for ISO-NE supply ancillary MC computation."""
+"""Tests for ISO-NE and NYISO supply ancillary marginal-cost helpers."""
 
 from __future__ import annotations
 
@@ -7,10 +7,15 @@ from datetime import datetime, timedelta
 import polars as pl
 import pytest
 
+import utils.data_prep.marginal_costs.supply_ancillary as supply_ancillary_mod
 from utils.data_prep.marginal_costs.supply_ancillary import (
+    ancillary_wide_to_enduse,
     compute_supply_ancillary_mc,
 )
-from utils.data_prep.marginal_costs.supply_utils import build_cairo_8760_timestamps
+from utils.data_prep.marginal_costs.supply_utils import (
+    build_cairo_8760_timestamps,
+    prepare_component_output,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -87,6 +92,138 @@ def test_load_ancillary_columns() -> None:
     assert result.columns == ["timestamp", "ancillary_cost_enduse"]
 
 
+def test_ancillary_wide_to_enduse_isone_matches_reg_sum_formula() -> None:
+    """Regression: ISO-NE wide → end-use must stay ``reg_service + reg_capacity``."""
+    raw = _make_ancillary_df(year=2025, n_hours=24)
+    from_module = ancillary_wide_to_enduse(raw, iso="isone", year=2025)
+    manual = (
+        raw.rename({"interval_start_et": "timestamp"})
+        .with_columns(
+            (
+                pl.col("reg_service_price_usd_per_mwh")
+                + pl.col("reg_capacity_price_usd_per_mwh")
+            ).alias("ancillary_cost_enduse")
+        )
+        .select("timestamp", "ancillary_cost_enduse")
+    )
+    assert from_module.schema == manual.schema
+    assert from_module["timestamp"].to_list() == manual["timestamp"].to_list()
+    assert from_module["ancillary_cost_enduse"].to_list() == pytest.approx(
+        manual["ancillary_cost_enduse"].to_list()
+    )
+
+
+def test_ancillary_wide_to_enduse_nyiso_one_hour_interval() -> None:
+    """NYISO: capacity + movement * (end - start in hours)."""
+    stub = pl.DataFrame(
+        {
+            "interval_start_et": [datetime(2025, 6, 1, 0, 0, 0)],
+            "interval_end_et": [datetime(2025, 6, 1, 1, 0, 0)],
+            "nyca_regulation_capacity_usd_per_mwhr": [10.0],
+            "nyca_regulation_movement_usd_per_mw": [2.0],
+        }
+    )
+    out = ancillary_wide_to_enduse(stub, iso="nyiso", year=2025)
+    assert out.columns == ["timestamp", "ancillary_cost_enduse"]
+    assert out["ancillary_cost_enduse"][0] == pytest.approx(12.0)
+
+
+def test_ancillary_wide_to_enduse_nyiso_five_minute_interval() -> None:
+    """Movement term scales with interval length in hours."""
+    stub = pl.DataFrame(
+        {
+            "interval_start_et": [datetime(2025, 6, 1, 0, 0, 0)],
+            "interval_end_et": [datetime(2025, 6, 1, 0, 5, 0)],
+            "nyca_regulation_capacity_usd_per_mwhr": [0.0],
+            "nyca_regulation_movement_usd_per_mw": [60.0],
+        }
+    )
+    out = ancillary_wide_to_enduse(stub, iso="nyiso", year=2025)
+    assert out["ancillary_cost_enduse"][0] == pytest.approx(5.0)
+
+
+def test_ancillary_wide_to_enduse_nyiso_null_movement_treated_as_zero() -> None:
+    stub = pl.DataFrame(
+        {
+            "interval_start_et": [datetime(2025, 6, 1, 0, 0, 0)],
+            "interval_end_et": [datetime(2025, 6, 1, 1, 0, 0)],
+            "nyca_regulation_capacity_usd_per_mwhr": [3.0],
+            "nyca_regulation_movement_usd_per_mw": [None],
+        }
+    )
+    out = ancillary_wide_to_enduse(stub, iso="nyiso", year=2025)
+    assert out["ancillary_cost_enduse"][0] == pytest.approx(3.0)
+
+
+def test_ancillary_wide_to_enduse_nyiso_null_capacity_treated_as_zero() -> None:
+    """Null regulation capacity is coerced to 0 before the movement term."""
+    stub = pl.DataFrame(
+        {
+            "interval_start_et": [datetime(2025, 6, 1, 0, 0, 0)],
+            "interval_end_et": [datetime(2025, 6, 1, 1, 0, 0)],
+            "nyca_regulation_capacity_usd_per_mwhr": [None],
+            "nyca_regulation_movement_usd_per_mw": [4.0],
+        }
+    )
+    out = ancillary_wide_to_enduse(stub, iso="nyiso", year=2025)
+    assert out["ancillary_cost_enduse"][0] == pytest.approx(4.0)
+
+
+def test_ancillary_wide_to_enduse_nyiso_two_hour_interval_formula() -> None:
+    """Regression spot-check: capacity + movement * Δt (hours)."""
+    stub = pl.DataFrame(
+        {
+            "interval_start_et": [datetime(2025, 3, 15, 12, 0, 0)],
+            "interval_end_et": [datetime(2025, 3, 15, 14, 0, 0)],
+            "nyca_regulation_capacity_usd_per_mwhr": [5.0],
+            "nyca_regulation_movement_usd_per_mw": [3.0],
+        }
+    )
+    out = ancillary_wide_to_enduse(stub, iso="nyiso", year=2025)
+    assert out["ancillary_cost_enduse"][0] == pytest.approx(5.0 + 3.0 * 2.0)
+
+
+def test_prepare_collapses_subhourly_nyiso_style_rows_to_hourly_mean() -> None:
+    """Matches ``prepare_component_output``: truncate to hour, mean duplicate hours."""
+    year = 2025
+    ref = build_cairo_8760_timestamps(year)
+    jan1_midnight = datetime(year, 1, 1, 0, 0, 0)
+    rest = (
+        ref.filter(pl.col("timestamp") != jan1_midnight)
+        .with_columns(pl.lit(1.0).alias("ancillary_cost_enduse"))
+        .select("timestamp", "ancillary_cost_enduse")
+    )
+    dup_hour = pl.DataFrame(
+        {
+            "timestamp": [jan1_midnight, datetime(year, 1, 1, 0, 30, 0)],
+            "ancillary_cost_enduse": [10.0, 14.0],
+        }
+    )
+    combined = pl.concat([dup_hour, rest], how="vertical").sort("timestamp")
+    out = prepare_component_output(
+        combined,
+        year=year,
+        input_col="ancillary_cost_enduse",
+        output_col="ancillary_cost_enduse",
+        scale=1.0,
+    )
+    row0 = out.filter(pl.col("timestamp") == jan1_midnight)
+    assert row0.height == 1
+    assert row0["ancillary_cost_enduse"][0] == pytest.approx(12.0)
+
+
+def test_nyiso_scan_columns_include_fetch_schema_core() -> None:
+    """NYISO parquet select list stays aligned with ``fetch_nyiso_as_prices_parquet``."""
+    cfg = supply_ancillary_mod._ancillary_config("nyiso")  # noqa: SLF001 — internal config table
+    names = set(cfg.scan_columns)
+    assert "interval_start_et" in names
+    assert "interval_end_et" in names
+    assert "market" in names
+    assert "nyca_regulation_capacity_usd_per_mwhr" in names
+    assert "nyca_regulation_movement_usd_per_mw" in names
+    assert "spin_10min_usd_per_mwhr" in names
+
+
 # ---------------------------------------------------------------------------
 # compute_supply_ancillary_mc (via monkeypatched load)
 # ---------------------------------------------------------------------------
@@ -117,7 +254,9 @@ def _make_compute_ancillary_mc_with_patch(
     def _fake_load(
         yr: int,
         storage_options: dict[str, str],
-        ancillary_s3_base: str = "",
+        ancillary_s3_base: str | None = None,
+        *,
+        iso: str = "isone",
     ) -> pl.DataFrame:
         return synthetic
 
@@ -126,6 +265,31 @@ def _make_compute_ancillary_mc_with_patch(
         year=year,
         storage_options={},
     )
+
+
+def test_compute_supply_ancillary_mc_passes_iso_to_load_ancillary_for_year(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``iso`` must reach ``load_ancillary_for_year`` (NYISO vs ISO-NE wiring)."""
+    captured: dict[str, object] = {}
+
+    def _fake_load(
+        yr: int,
+        storage_options: dict[str, str],
+        ancillary_s3_base: str | None = None,
+        *,
+        iso: str = "isone",
+    ) -> pl.DataFrame:
+        captured["year"] = yr
+        captured["iso"] = iso
+        captured["ancillary_s3_base"] = ancillary_s3_base
+        ts = build_cairo_8760_timestamps(yr)
+        return ts.with_columns(pl.lit(2.5).alias("ancillary_cost_enduse"))
+
+    monkeypatch.setattr(supply_ancillary_mod, "load_ancillary_for_year", _fake_load)
+    compute_supply_ancillary_mc(2025, {}, iso="nyiso")
+    assert captured["iso"] == "nyiso"
+    assert captured["year"] == 2025
 
 
 def test_compute_ancillary_mc_returns_8760_rows(
@@ -192,7 +356,9 @@ def test_compute_ancillary_mc_leap_year_is_8760(
     def _fake_load(
         yr: int,
         storage_options: dict[str, str],
-        ancillary_s3_base: str = "",
+        ancillary_s3_base: str | None = None,
+        *,
+        iso: str = "isone",
     ) -> pl.DataFrame:
         return synthetic
 

--- a/utils/data_prep/marginal_costs/generate_supply_ancillary_mc.py
+++ b/utils/data_prep/marginal_costs/generate_supply_ancillary_mc.py
@@ -1,18 +1,24 @@
-"""Generate utility-level ISO-NE supply ancillary service marginal costs."""
+"""Generate utility-level ISO-NE or NYISO supply ancillary service marginal costs."""
 
 from __future__ import annotations
 
 import argparse
+import sys
 
 from dotenv import load_dotenv
 
-from data.eia.hourly_loads.eia_region_config import get_aws_storage_options
-from utils.data_prep.marginal_costs.supply_ancillary import compute_supply_ancillary_mc
+from utils.data_prep.marginal_costs.supply_ancillary import (
+    AncillaryIso,
+    compute_supply_ancillary_mc,
+)
 from utils.data_prep.marginal_costs.supply_utils import (
     DEFAULT_ISONE_ANCILLARY_S3_BASE,
     DEFAULT_ISONE_OUTPUT_S3_BASE,
+    DEFAULT_NYISO_ANCILLARY_S3_BASE,
+    DEFAULT_NYISO_OUTPUT_S3_BASE,
     ISONE_UTILITY_ZONES,
     VALID_ISONE_UTILITIES,
+    VALID_NYISO_UTILITIES,
     save_component_output,
 )
 
@@ -21,15 +27,21 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Generate utility-level supply ancillary service marginal costs "
-            "from ISO-NE regulation clearing prices."
+            "from ISO-NE or NYISO regulation-related clearing prices."
         )
+    )
+    parser.add_argument(
+        "--iso",
+        type=str,
+        choices=("isone", "nyiso"),
+        default="isone",
+        help="Market: isone (default) or nyiso.",
     )
     parser.add_argument(
         "--utility",
         type=str,
         required=True,
-        choices=sorted(VALID_ISONE_UTILITIES),
-        help=f"Utility short name. One of: {sorted(VALID_ISONE_UTILITIES)}.",
+        help="Utility short name (valid set depends on --iso).",
     )
     parser.add_argument(
         "--year",
@@ -42,21 +54,24 @@ def _parse_args() -> argparse.Namespace:
         type=str,
         default=None,
         help=(
-            "Load zone (informational; ancillary data is not zone-partitioned). "
-            "Defaults to the zone mapped to --utility in ISONE_UTILITY_ZONES."
+            "Load zone (informational for ISO-NE; ancillary data is not zone-partitioned). "
+            "Defaults to the zone mapped to --utility when using ISO-NE."
         ),
     )
     parser.add_argument(
         "--ancillary-s3-base",
         type=str,
-        default=DEFAULT_ISONE_ANCILLARY_S3_BASE,
-        help=f"S3 base for ISO-NE ancillary data (default: {DEFAULT_ISONE_ANCILLARY_S3_BASE}).",
+        default="",
+        help=(
+            "S3 base for ancillary parquet (default: ISO-NE or NYISO canonical path "
+            "matching --iso)."
+        ),
     )
     parser.add_argument(
         "--output-s3-base",
         type=str,
-        default=DEFAULT_ISONE_OUTPUT_S3_BASE,
-        help=f"S3 base for output (default: {DEFAULT_ISONE_OUTPUT_S3_BASE}).",
+        default="",
+        help="S3 base for output (default: RI supply vs NY supply matching --iso).",
     )
     parser.add_argument(
         "--upload",
@@ -68,28 +83,73 @@ def _parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = _parse_args()
+    iso: AncillaryIso = "isone" if args.iso == "isone" else "nyiso"
+
+    if iso == "isone" and args.utility not in VALID_ISONE_UTILITIES:
+        print(
+            f"ERROR: --utility must be one of {sorted(VALID_ISONE_UTILITIES)} "
+            "for --iso isone",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if iso == "nyiso" and args.utility not in VALID_NYISO_UTILITIES:
+        print(
+            f"ERROR: --utility must be one of {sorted(VALID_NYISO_UTILITIES)} "
+            "for --iso nyiso",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    ancillary_s3_base = (
+        args.ancillary_s3_base
+        if args.ancillary_s3_base
+        else (
+            DEFAULT_ISONE_ANCILLARY_S3_BASE
+            if iso == "isone"
+            else DEFAULT_NYISO_ANCILLARY_S3_BASE
+        )
+    )
+    output_s3_base = (
+        args.output_s3_base
+        if args.output_s3_base
+        else (
+            DEFAULT_ISONE_OUTPUT_S3_BASE
+            if iso == "isone"
+            else DEFAULT_NYISO_OUTPUT_S3_BASE
+        )
+    )
+
     load_dotenv()
+    from data.eia.hourly_loads.eia_region_config import get_aws_storage_options
+
     storage_options = get_aws_storage_options()
 
     utility = args.utility
     price_year = args.year
-    zone = args.zone or ISONE_UTILITY_ZONES.get(utility, "unknown")
+    zone = (
+        args.zone
+        if args.zone is not None
+        else (ISONE_UTILITY_ZONES.get(utility, "unknown") if iso == "isone" else "n/a")
+    )
 
+    iso_title = "ISO-NE" if iso == "isone" else "NYISO"
     print("=" * 60)
-    print("SUPPLY ANCILLARY MARGINAL COST GENERATION (ISO-NE)")
+    print(f"SUPPLY ANCILLARY MARGINAL COST GENERATION ({iso_title})")
     print("=" * 60)
+    print(f"  ISO:                  {iso}")
     print(f"  Utility:              {utility}")
     print(f"  Zone:                 {zone}")
     print(f"  Price year:           {price_year}")
-    print(f"  Ancillary S3 base:    {args.ancillary_s3_base}")
+    print(f"  Ancillary S3 base:    {ancillary_s3_base}")
     print(f"  Upload to S3:         {'Yes' if args.upload else 'No (inspect only)'}")
     print("=" * 60)
 
-    print("\n── Ancillary MC (Regulation Service + Capacity) ──")
+    print("\n── Ancillary MC ──")
     ancillary_output = compute_supply_ancillary_mc(
         year=price_year,
         storage_options=storage_options,
-        ancillary_s3_base=args.ancillary_s3_base,
+        ancillary_s3_base=ancillary_s3_base,
+        iso=iso,
     )
 
     print("\n── Output Preparation ──")
@@ -103,7 +163,7 @@ def main() -> None:
             component_df=ancillary_output,
             utility=utility,
             year=price_year,
-            output_s3_base=args.output_s3_base,
+            output_s3_base=output_s3_base,
             storage_options=storage_options,
             component="ancillary",
         )

--- a/utils/data_prep/marginal_costs/supply_ancillary.py
+++ b/utils/data_prep/marginal_costs/supply_ancillary.py
@@ -1,79 +1,103 @@
-"""Ancillary service marginal cost computation for ISO-NE supply MCs."""
+"""Ancillary service marginal cost computation for ISO-NE and NYISO supply MCs."""
 
 from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, assert_never
 
 import polars as pl
 
 from utils.data_prep.marginal_costs.supply_utils import (
     DEFAULT_ISONE_ANCILLARY_S3_BASE,
+    DEFAULT_NYISO_ANCILLARY_S3_BASE,
     prepare_component_output,
     strip_tz_if_needed,
 )
 
+AncillaryIso = Literal["isone", "nyiso"]
 
-def load_ancillary_for_year(
+# Hive parquet interval column (shared naming across ISO ancillary datasets).
+_INTERVAL_START_COL = "interval_start_et"
+
+
+@dataclass(frozen=True)
+class AncillaryPipelineConfig:
+    """Per-ISO settings: which columns to read and how errors/notes are labeled."""
+
+    iso: AncillaryIso
+    scan_columns: tuple[str, ...]
+    data_label: str
+    backfill_hint: str
+
+    def duplicate_interval_note(self, n_dup: int, n_rows: int, n_unique: int) -> str:
+        """Human-readable note when naive ``interval_start_et`` values collide."""
+        if self.iso == "isone":
+            return (
+                f"  DST fallback: {n_dup} duplicate naive timestamp(s) detected "
+                f"({n_rows} rows, {n_unique} unique). Both fallback-hour values will be "
+                f"preserved and averaged during alignment to 8760."
+            )
+        return (
+            f"  {self.data_label}: {n_dup} duplicate {_INTERVAL_START_COL} value(s) "
+            f"({n_rows} rows, {n_unique} unique naive timestamps)."
+        )
+
+
+def _ancillary_config(iso: AncillaryIso) -> AncillaryPipelineConfig:
+    if iso == "isone":
+        return AncillaryPipelineConfig(
+            iso="isone",
+            scan_columns=(
+                _INTERVAL_START_COL,
+                "reg_service_price_usd_per_mwh",
+                "reg_capacity_price_usd_per_mwh",
+            ),
+            data_label="ISO-NE ancillary",
+            backfill_hint="s3://data.sb/isone/ancillary/",
+        )
+    if iso == "nyiso":
+        return AncillaryPipelineConfig(
+            iso="nyiso",
+            scan_columns=(
+                "year",
+                "month",
+                "market",
+                "time_et",
+                _INTERVAL_START_COL,
+                "interval_end_et",
+                "zone",
+                "time_zone",
+                "ptid",
+                "spin_10min_usd_per_mwhr",
+                "non_sync_10min_usd_per_mwhr",
+                "operating_30min_usd_per_mwhr",
+                "nyca_regulation_capacity_usd_per_mwhr",
+                "nyca_regulation_movement_usd_per_mw",
+            ),
+            data_label="NYISO ancillary",
+            backfill_hint="s3://data.sb/nyiso/ancillary/",
+        )
+    raise ValueError(f"Invalid ISO: {iso}")
+
+
+def _default_ancillary_s3_base(iso: AncillaryIso) -> str:
+    if iso == "isone":
+        return DEFAULT_ISONE_ANCILLARY_S3_BASE
+    if iso == "nyiso":
+        return DEFAULT_NYISO_ANCILLARY_S3_BASE
+    raise ValueError(f"Invalid ISO: {iso}")
+
+
+def _validate_calendar_months(
+    df: pl.DataFrame,
+    *,
+    timestamp_col: str,
     year: int,
-    storage_options: dict[str, str],
-    ancillary_s3_base: str = DEFAULT_ISONE_ANCILLARY_S3_BASE,
-) -> pl.DataFrame:
-    """Load ISO-NE ancillary service prices for a given year.
-
-    Reads from the Hive-partitioned ``s3://data.sb/isone/ancillary/`` tree,
-    filters by *year*, sums ``reg_service_price_usd_per_mwh`` and
-    ``reg_capacity_price_usd_per_mwh`` into a single ``ancillary_cost_enduse``
-    column ($/MWh), and returns a DataFrame with columns ``timestamp`` and
-    ``ancillary_cost_enduse``.
-    """
-    base = ancillary_s3_base.rstrip("/") + "/"
-    collected = (
-        pl.scan_parquet(
-            base,
-            hive_partitioning=True,
-            storage_options=storage_options,
-        )
-        .filter(pl.col("year") == year)
-        .select(
-            "interval_start_et",
-            "reg_service_price_usd_per_mwh",
-            "reg_capacity_price_usd_per_mwh",
-        )
-        .collect()
-    )
-    if not isinstance(collected, pl.DataFrame):
-        raise TypeError("Expected DataFrame from ISO-NE ancillary collect()")
-    if collected.is_empty():
-        raise FileNotFoundError(
-            f"No ISO-NE ancillary data found for year={year} under {base}"
-        )
-
-    collected = strip_tz_if_needed(collected, "interval_start_et").rename(
-        {"interval_start_et": "timestamp"}
-    )
-
-    # Report DST fallback duplicates explicitly. Stripping the tz from an
-    # America/New_York timestamp makes the two 1:00 AM fall-back hours collide
-    # on the same naive timestamp. We surface that here; prepare_component_output
-    # will average the pair and align the series to exactly 8760 hours.
-    n_rows = collected.height
-    n_unique_ts = collected.select(pl.col("timestamp").n_unique()).item()
-    if n_rows != n_unique_ts:
-        n_dst_dup = n_rows - n_unique_ts
-        print(
-            f"  DST fallback: {n_dst_dup} duplicate naive timestamp(s) detected "
-            f"({n_rows} rows, {n_unique_ts} unique). Both fallback-hour values will be "
-            f"preserved and averaged during alignment to 8760."
-        )
-
-    result = collected.with_columns(
-        (
-            pl.col("reg_service_price_usd_per_mwh")
-            + pl.col("reg_capacity_price_usd_per_mwh")
-        ).alias("ancillary_cost_enduse")
-    ).select("timestamp", "ancillary_cost_enduse")
-
-    # Validate data completeness - check for missing months
+    data_label: str,
+    backfill_hint: str,
+) -> None:
     months_present = (
-        result.with_columns(pl.col("timestamp").dt.month().alias("month"))
+        df.with_columns(pl.col(timestamp_col).dt.month().alias("month"))
         .select("month")
         .unique()
         .sort("month")
@@ -84,35 +108,180 @@ def load_ancillary_for_year(
     missing_months = sorted(set(expected_months) - set(months_present))
     if missing_months:
         raise ValueError(
-            f"ISO-NE ancillary data is incomplete for year {year}. "
+            f"{data_label} data is incomplete for year {year}. "
             f"Missing months: {missing_months}. Present months: {months_present}. "
-            f"Backfill missing months in source data (s3://data.sb/isone/ancillary/) "
+            f"Backfill missing months in source data ({backfill_hint}) "
             f"before generating marginal costs."
         )
 
-    avg_ancillary = result["ancillary_cost_enduse"].mean()
-    print(
-        f"Loaded ISO-NE ancillary data: {len(result):,} hourly rows, year {year}, "
-        f"avg ancillary cost = ${avg_ancillary:.2f}/MWh"
+
+def load_ancillary_source_for_year(
+    year: int,
+    storage_options: dict[str, str],
+    ancillary_s3_base: str | None,
+    *,
+    iso: AncillaryIso,
+) -> pl.DataFrame:
+    """Load one ISO's ancillary parquet rows for *year* (wide schema, no end-use sum).
+
+    Strips timezone from ``interval_start_et`` when present, validates calendar
+    month coverage, and emits a note if duplicate naive interval timestamps exist
+    (e.g. ISO-NE DST fall-back).
+
+    Raises:
+        FileNotFoundError: If no rows exist for *year*.
+        ValueError: If any calendar month is missing.
+    """
+    cfg = _ancillary_config(iso)
+    base = (ancillary_s3_base or _default_ancillary_s3_base(iso)).rstrip("/") + "/"
+    collected = (
+        pl.scan_parquet(
+            base,
+            hive_partitioning=True,
+            storage_options=storage_options,
+        )
+        .filter(pl.col("year") == year)
+        .select(cfg.scan_columns)
+        .collect()
     )
-    return result
+    if not isinstance(collected, pl.DataFrame):
+        raise TypeError(
+            f"Expected DataFrame from ancillary collect() ({cfg.data_label})"
+        )
+    if collected.is_empty():
+        raise FileNotFoundError(
+            f"No ancillary data found for year={year} under {base} ({cfg.data_label})"
+        )
+
+    collected = strip_tz_if_needed(collected, _INTERVAL_START_COL)
+    if iso == "nyiso" and "interval_end_et" in collected.columns:
+        collected = strip_tz_if_needed(collected, "interval_end_et")
+    if iso == "nyiso" and "time_et" in collected.columns:
+        collected = strip_tz_if_needed(collected, "time_et")
+    _validate_calendar_months(
+        collected,
+        timestamp_col=_INTERVAL_START_COL,
+        year=year,
+        data_label=cfg.data_label,
+        backfill_hint=cfg.backfill_hint,
+    )
+
+    n_rows = collected.height
+    n_unique_ts = collected.select(pl.col(_INTERVAL_START_COL).n_unique()).item()
+    # NYISO often has many rows per interval_start_et (zones/markets); only ISO-NE
+    # uses duplicate naive timestamps as a DST fall-back signal.
+    if iso == "isone" and n_rows != n_unique_ts:
+        print(cfg.duplicate_interval_note(n_rows - n_unique_ts, n_rows, n_unique_ts))
+
+    return collected
+
+
+def ancillary_wide_to_enduse(
+    df: pl.DataFrame,
+    *,
+    iso: AncillaryIso,
+    year: int,
+) -> pl.DataFrame:
+    """Reduce wide ancillary *df* to ``timestamp`` + ``ancillary_cost_enduse`` ($/MWh).
+
+    ISO-specific rules are isolated in ``iso`` branches: which price columns exist on
+    *df* and how they combine into one end-use marginal cost series.
+
+    Raises:
+        ValueError: If output timestamps do not cover all calendar months for *year*.
+    """
+    cfg = _ancillary_config(iso)
+    if iso == "isone":
+        out = (
+            df.rename({_INTERVAL_START_COL: "timestamp"})
+            .with_columns(
+                (
+                    pl.col("reg_service_price_usd_per_mwh")
+                    + pl.col("reg_capacity_price_usd_per_mwh")
+                ).alias("ancillary_cost_enduse")
+            )
+            .select("timestamp", "ancillary_cost_enduse")
+        )
+        avg_ancillary = out["ancillary_cost_enduse"].mean()
+        print(
+            f"Loaded {cfg.data_label}: {len(out):,} hourly rows, year {year}, "
+            f"avg ancillary cost = ${avg_ancillary:.2f}/MWh"
+        )
+        return out
+
+    if iso == "nyiso":
+        work = strip_tz_if_needed(df, _INTERVAL_START_COL)
+        work = strip_tz_if_needed(work, "interval_end_et")
+        interval_hours = (
+            pl.col("interval_end_et") - pl.col(_INTERVAL_START_COL)
+        ).dt.total_seconds() / 3600.0
+        out = (
+            work.with_columns(
+                pl.col("nyca_regulation_capacity_usd_per_mwhr").fill_null(0.0),
+                pl.col("nyca_regulation_movement_usd_per_mw").fill_null(0.0),
+            )
+            .with_columns(interval_hours.alias("_interval_hours"))
+            .with_columns(
+                (
+                    pl.col("nyca_regulation_capacity_usd_per_mwhr")
+                    + pl.col("nyca_regulation_movement_usd_per_mw")
+                    * pl.col("_interval_hours")
+                ).alias("ancillary_cost_enduse")
+            )
+            .drop("_interval_hours")
+            .rename({_INTERVAL_START_COL: "timestamp"})
+            .select("timestamp", "ancillary_cost_enduse")
+        )
+        avg_ancillary = out["ancillary_cost_enduse"].mean()
+        print(
+            f"Loaded {cfg.data_label}: {len(out):,} interval rows, year {year}, "
+            f"avg combined ancillary = ${avg_ancillary:.2f}/MWh (pre-hourly-alignment)"
+        )
+        return out
+
+    assert_never(iso)
+
+
+def load_ancillary_for_year(
+    year: int,
+    storage_options: dict[str, str],
+    ancillary_s3_base: str | None = None,
+    *,
+    iso: AncillaryIso = "isone",
+) -> pl.DataFrame:
+    """Load ancillary prices for *year* and reduce to ``timestamp`` + ``ancillary_cost_enduse``.
+
+    Uses :func:`load_ancillary_source_for_year` then :func:`ancillary_wide_to_enduse`.
+    When *ancillary_s3_base* is omitted, the default base matches *iso*.
+    """
+    base = ancillary_s3_base or _default_ancillary_s3_base(iso)
+    wide = load_ancillary_source_for_year(year, storage_options, base, iso=iso)
+    return ancillary_wide_to_enduse(wide, iso=iso, year=year)
 
 
 def compute_supply_ancillary_mc(
     year: int,
     storage_options: dict[str, str],
-    ancillary_s3_base: str = DEFAULT_ISONE_ANCILLARY_S3_BASE,
+    ancillary_s3_base: str | None = None,
+    *,
+    iso: AncillaryIso = "isone",
 ) -> pl.DataFrame:
-    """Compute hourly supply ancillary MC from ISO-NE regulation clearing prices.
+    """Compute hourly supply ancillary MC from ISO regulation-related clearing prices.
 
-    Loads ISO-NE ancillary data, sums regulation service and capacity prices,
-    and returns a Cairo-compatible 8760 hourly DataFrame with columns
-    ``timestamp`` and ``ancillary_cost_enduse`` ($/MWh).
+    Loads ancillary data for *iso*, aggregates to ``ancillary_cost_enduse`` ($/MWh),
+    and returns a Cairo-compatible 8760 hourly DataFrame with columns ``timestamp``
+    and ``ancillary_cost_enduse``.
 
     Raises:
         ValueError: If source data is incomplete (missing months).
     """
-    ancillary_df = load_ancillary_for_year(year, storage_options, ancillary_s3_base)
+    resolved_base = ancillary_s3_base or _default_ancillary_s3_base(iso)
+    ancillary_df = load_ancillary_for_year(
+        year,
+        storage_options,
+        resolved_base,
+        iso=iso,
+    )
     output = prepare_component_output(
         df=ancillary_df,
         year=year,
@@ -121,9 +290,10 @@ def compute_supply_ancillary_mc(
         scale=1.0,
     )
 
+    iso_label = "ISO-NE" if iso == "isone" else "NYISO"
     avg_cost = output["ancillary_cost_enduse"].mean()
     print(
-        f"  Ancillary MC (ISO-NE): {output.height} hours, "
+        f"  Ancillary MC ({iso_label}): {output.height} hours, "
         f"avg cost = ${avg_cost:.2f}/MWh"
     )
     return output

--- a/utils/data_prep/marginal_costs/supply_utils.py
+++ b/utils/data_prep/marginal_costs/supply_utils.py
@@ -22,6 +22,7 @@ DEFAULT_NYISO_ZONE_MAPPING_PATH = (
     "s3://data.sb/nyiso/zone_mapping/ny_utility_zone_mapping.csv"
 )
 DEFAULT_NYISO_OUTPUT_S3_BASE = "s3://data.sb/switchbox/marginal_costs/ny/supply/"
+DEFAULT_NYISO_ANCILLARY_S3_BASE = "s3://data.sb/nyiso/ancillary/"
 
 VALID_NYISO_UTILITIES = frozenset(
     {"cenhud", "coned", "nimo", "nyseg", "or", "rge", "psegli"}


### PR DESCRIPTION
## Overview

Salvages the *generation* capability from the stale, broken branch `396-create-8760s-of-ancillary-cost-data-for-ny` (PR #403) into a clean, purely additive change. This lets us generate NY supply ancillary marginal costs from NYISO ancillary-services clearing prices, **without changing any published RIE/NY results** and **without enforcing** ancillary on existing runs.

The published NY report is done, so all result-affecting config (tariffs, calibrated JSONs, gas tariff maps, rev_requirements, scenarios, master-bill/bat run logic) is intentionally left to default to `main`.

## What's included

- `data/nyiso/ancillary/`: fetch / validate / update pipeline for NYISO AS prices (mirrors `data/isone/ancillary/` conventions).
- `utils/data_prep/marginal_costs/supply_ancillary.py` + `generate_supply_ancillary_mc.py`: `--iso nyiso` support (NYISO regulation capacity + movement). The ISO-NE path is behavior-preserving, so RI generation is unchanged.
- `utils/data_prep/marginal_costs/supply_utils.py`: `DEFAULT_NYISO_ANCILLARY_S3_BASE`.
- `rate_design/hp_rates/ny/Justfile`: opt-in `create-supply-ancillary-mc-data[-all]` recipes (deliberately **not** wired into `create-supply-mc-data`).
- Tests for the NYISO transform and end-use ancillary computation.

## Why no enforcement

`main` already consumes `path_supply_ancillary_mc` in `run_scenario.py` (gated on `run_includes_supply`) and threads `SUPPLY_ANCILLARY_MC` (blank default) through the shared `Justfile`. So enabling NY ancillary later is just: generate the parquet via the new recipe, then set `SUPPLY_ANCILLARY_MC` before a supply run. No auto-fill / silent path guessing.

## Reviewer focus

- Confirm the ISO-NE ancillary path is unchanged vs `main` (RI results must be identical).
- The NYISO end-use formula: `nyca_regulation_capacity + nyca_regulation_movement * interval_hours`.

## Notes

- The original broken branch is preserved as tag `archive/396-create-8760s-of-ancillary-cost-data-for-ny`.
- `just check` passes; full suite passes except 2 pre-existing, unrelated ResStock S3 data-count failures.

Refs #396.

Made with [Cursor](https://cursor.com)