### PR TITLE
Implement PJM supply capacity marginal cost (RPM 5CP) for BGE

### DIFF
--- a/context/domain/marginal_costs/pjm_supply_capacity_marginal_cost.md
+++ b/context/domain/marginal_costs/pjm_supply_capacity_marginal_cost.md
@@ -6,7 +6,7 @@ Related docs:
 
 - `context/methods/marginal_costs/capacity_market_comparison_nyiso_isone.md` — NYISO ICAP vs ISO-NE FCM
 - `context/code/marginal_costs/ny_supply_marginal_costs.md` — NY implementation (monthly ICAP)
-- `utils/pre/marginal_costs/supply_capacity_isone.py` — closest platform template (annual FCA + exceedance)
+- `utils/data_prep/marginal_costs/supply_capacity_isone.py` — closest platform template (annual FCA + exceedance)
 
 ---
 
@@ -144,14 +144,16 @@ $$\text{LRC} = \text{Daily UCAP Obligation (MW)} \times \text{Final Zonal Capaci
 
 ### Annualizing for BAT
 
-For a **calendar year** analysis (e.g. 2025), blend two overlapping delivery years (same logic as ISO-NE CCP):
+For a **calendar year** analysis (e.g. 2025), blend the two overlapping delivery years (same idea as the ISO-NE CCP blend):
 
-- **DY1** (Jun 2024–May 2025): covers Jan–May of calendar year → **5 months**
-- **DY2** (Jun 2025–May 2026): covers Jun–Dec of calendar year → **7 months**
+- **DY1** (Jun 2024–May 2025): covers Jan 1 – May 31 of the calendar year
+- **DY2** (Jun 2025–May 2026): covers Jun 1 – Dec 31 of the calendar year
 
-$$\text{capacity\_cost\_kw\_year} = P_{\text{DY1}} \times 5 + P_{\text{DY2}} \times 7$$
+The RPM Final Zonal Capacity Price is natively `$/MW-day`, so we blend by the **actual number of calendar-year days** each DY covers (an exact day-count blend), rather than ISO-NE's `$/kW-month × months` shape:
 
-where $P$ is the annualized `$/kW-year` from Final Zonal Capacity Price (convert from `$/MW-day`).
+$$\overline{P}_{\text{kW-yr}} = \frac{P^{\text{day}}_{\text{DY1}} \cdot d_{\text{Jan–May}} + P^{\text{day}}_{\text{DY2}} \cdot d_{\text{Jun–Dec}}}{1000}$$
+
+where $P^{\text{day}}$ is the Final Zonal Capacity Price in `$/MW-day`, $d_{\text{Jan–May}}$ is 151 days (152 in a leap year), $d_{\text{Jun–Dec}}$ is 214 days, and the `/1000` converts MW → kW. (The earlier `× 5 / × 7` month split is the same idea approximated to whole months; the day-count form is exact and dimensionally consistent for a daily price.)
 
 ---
 
@@ -227,7 +229,16 @@ Each decision below is **independent**. Recommended defaults are marked ★.
 | **F2 Exceedance weighting** | Threshold-exceedance among the 5 hours (or top-K from summer pool) | Consistent with `allocate_annual_exceedance_to_hours` in `supply_utils.py`; used for RI | **Not** how PLC is defined (average, not exceedance) |
 | **F3 Load-proportional**    | Weight by zone load in each hour                                   | Simple physical interpretation                                                          | Still not identical to PLC reconciliation            |
 
-**Recommendation:** F1 if prioritizing PJM fidelity; F2 if prioritizing platform consistency. Document the choice explicitly.
+**Decision: F1 (equal 1/K weights).** This is the implemented choice in `supply_capacity_pjm.py`.
+
+**Rationale.** PJM defines a customer's capacity obligation (PLC) as the **simple average** of that customer's reconciled load across the five coincident-peak hours (PJM Manual 19 §4.3; BGE PLC Overview). Averaging across the five hours is mathematically equivalent to giving each hour a weight of exactly **1/5**. Equal weighting is therefore the literal analog of how the capacity obligation is assigned: it is _definitionally_ correct, not merely a convenient default. The exceedance (F2) and load-proportional (F3) alternatives re-introduce a within-peak load signal that the PLC _average_ deliberately removes, so both deviate from the obligation definition. F2 is retained only as a cross-component-consistency sensitivity (it matches the RI dist/bulk-TX convention), not as a capacity-fidelity option.
+
+**Empirical note (BGE).** For BGE the choice is also immaterial in practice: BGE's zonal load at the five summer-2025 5CP hours is nearly flat (≈ 6.1–6.6 GW), so F1 vs. load-weighting changes the within-peak split by only about ±4%. Both options place the same total `$/kW-year` on the same five hours.
+
+**Sources:**
+
+- [PJM Manual 19 §4.3 — Peak Load Allocation (5CP), PLC = average of five hourly loads](https://www.pjm.com/-/media/DotCom/documents/manuals/m19.pdf)
+- [BGE Peak Load Contribution (PLC) Overview — "average of … load during those five hours"](https://supplier.bge.com/electric/load/plcs.asp)
 
 ---
 
@@ -278,7 +289,7 @@ For any new PJM utility MC pipeline:
 ## 7. Zone and LDA
 
 - BGE serves the **BGE zone** in PJM (Maryland territory).
-- BGE is **not** a separately constrained LDA; it typically clears at the **RTO** Final Zonal Capacity Price.
+- BGE **is frequently a separately constrained LDA**: in the curated RPM dataset it clears at a BGE-specific Final Zonal Capacity Price (above the RTO system price) in 6 of 9 delivery years, including DY2024/25 and DY2025/26 (the DYs that feed calendar-year 2025). The implementation therefore selects the utility's **own zone row** (`zone == "BGE"`) and uses its `final_zonal_capacity_price_per_mw_day`, which already incorporates the locational adder — it does **not** assume the RTO price. (Only DY2018/19 and DY2026/27 had BGE at the RTO price.)
 - Pepco/DPL serve other Maryland areas under different zones/LDAs — do not reuse BGE prices for them.
 
 **Sources:**
@@ -376,16 +387,16 @@ Useful for validating order-of-magnitude but **not** a direct hourly MC formula.
 
 ## 11. ★ Recommended BGE v1 package
 
-| Parameter              | BGE choice                                                                                   |
-| ---------------------- | -------------------------------------------------------------------------------------------- |
-| LDA / price zone       | RTO (BGE zone unconstrained)                                                                 |
-| Price                  | Final Zonal Capacity Price, 5/7 DY calendar-year blend; sensitivity with IA-trued price      |
-| K                      | 5 (PJM 5CP timestamps)                                                                       |
-| Season                 | Jun 1 – Sep 30                                                                               |
-| Load                   | BGE zone load at 5CP timestamps (E1)                                                         |
-| Weights                | Equal 1/5 (F1, PLC-average)                                                                  |
-| Bill side              | Schedule R flat SOS; note PSC shoulder smoothing as non-MC                                   |
-| Output path (proposed) | `s3://data.sb/switchbox/marginal_costs/md/supply/capacity/utility=bge/year={Y}/data.parquet` |
+| Parameter              | BGE choice                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------- |
+| LDA / price zone       | BGE zone (a constrained LDA in most DYs; use the BGE Final Zonal price, which bakes in the adder) |
+| Price                  | Final Zonal Capacity Price, 5/7 DY calendar-year blend; sensitivity with IA-trued price           |
+| K                      | 5 (PJM 5CP timestamps)                                                                            |
+| Season                 | Jun 1 – Sep 30                                                                                    |
+| Load                   | BGE zone load at 5CP timestamps (E1)                                                              |
+| Weights                | Equal 1/5 (F1, PLC-average)                                                                       |
+| Bill side              | Schedule R flat SOS; note PSC shoulder smoothing as non-MC                                        |
+| Output path (proposed) | `s3://data.sb/switchbox/marginal_costs/md/supply/capacity/utility=bge/year={Y}/data.parquet`      |
 
 ---
 
@@ -412,15 +423,13 @@ Useful for validating order-of-magnitude but **not** a direct hourly MC formula.
 
 Implemented (curated data pipelines, reproducible from committed source intermediates):
 
-- `data/pjm/capacity/rpm/` — RPM BRA + Final Zonal prices, DY 2018/19–2026/27. Per-DY markdown intermediates under `sources/` (`rpm_YYYY_YY.md`, both source URLs in the header) → `just convert` → CSV. Rows carry `source_url` (final zonal) and `bra_source_url` citations.
-- `data/pjm/capacity/5cp/` — summer 5CP peaks, **summers 2021–2025** (only those feeding 2025+ runs are retained; earlier summers dropped). Per-summer markdown intermediates under `sources/` (`5cp_YYYY.md`) → `just convert` → CSV.
+- `data/pjm/capacity/rpm/` — RPM BRA + Final Zonal prices, DY 2018/19–2026/27. Per-DY markdown intermediates under `sources/` (`rpm_YYYY_YY.md`, both source URLs in the header) → `just convert` → CSV → `s3://data.sb/pjm/capacity/rpm/data.parquet`. Rows carry `source_url` (final zonal) and `bra_source_url` citations.
+- `data/pjm/capacity/5cp/` — summer 5CP peaks, **summers 2021–2025** (only those feeding 2025+ runs are retained; earlier summers dropped). Per-summer markdown intermediates under `sources/` (`5cp_YYYY.md`) → `just convert` → CSV → `s3://data.sb/pjm/capacity/5cp/data.parquet`.
 - `data/pjm/zone_mapping/` — utility → zone/LDA crosswalk.
-
-Not yet implemented:
-
-- `data/pjm/hourly_demand/zones/` — zone load pipeline (deferred; see Future work below)
-- `utils/pre/marginal_costs/supply_capacity_pjm.py` — computation
-- `rate_design/hp_rates/md/` — state config (future)
+- `data/pjm/hourly_demand/zones/` — PJM-native zonal hourly loads on S3 (only needed for the E1/F2 load-weighted sensitivity, not the v1 equal-weight pipeline).
+- `utils/data_prep/marginal_costs/supply_capacity_pjm.py` — computation (RPM day-count blend + 5CP equal-weight allocation + 1 kW validation).
+- `generate_supply_capacity_mc.py --iso pjm` — CLI entrypoint.
+- `rate_design/hp_rates/md/Justfile` — `create-supply-capacity-mc[-all-years|-all|-full-backfill]` recipes.
 
 ---
 
@@ -441,4 +450,4 @@ Not yet implemented:
 13. [MD PSC Order 87591 — BGE rate case (PDF)](https://psc.maryland.gov/wp-content/uploads/Order-No.-87591-Case-No.-9406-BGE-Rate-Case.pdf)
 14. Platform: `context/methods/marginal_costs/capacity_market_comparison_nyiso_isone.md`
 15. Platform: `context/code/marginal_costs/ny_supply_marginal_costs.md`
-16. Platform: `utils/pre/marginal_costs/supply_capacity_isone.py`
+16. Platform: `utils/data_prep/marginal_costs/supply_capacity_isone.py`

--- a/rate_design/hp_rates/md/Justfile
+++ b/rate_design/hp_rates/md/Justfile
@@ -102,3 +102,77 @@ create-supply-energy-mc-full-backfill *extra_args:
         done
     done
     echo ">> Done: full backfill" >&2
+
+# =============================================================================
+# MD-only: supply capacity marginal costs (PJM RPM + 5CP)
+# =============================================================================
+
+# Years with both an RPM calendar-year blend and a published summer 5CP set.
+# 5CP data covers summers 2021-2025; RPM covers DY 2018/19-2026/27. The binding
+# constraint is the 5CP summer, so capacity MC is available for 2021-2025.
+pjm_capacity_years := "2021 2022 2023 2024 2025"
+
+# Generate supply capacity MC for one MD utility and one year.
+#
+#   just -f md/Justfile create-supply-capacity-mc bge 2025
+# just -f md/Justfile create-supply-capacity-mc bge 2025 --upload
+create-supply-capacity-mc utility year *extra_args:
+    uv run python {{ path_repo }}/utils/data_prep/marginal_costs/generate_supply_capacity_mc.py \
+      --iso pjm \
+      --utility {{ utility }} \
+      --year {{ year }} \
+      {{ extra_args }}
+
+# Generate supply capacity MC for one utility across all available years.
+#
+#   just -f md/Justfile create-supply-capacity-mc-all-years bge
+# just -f md/Justfile create-supply-capacity-mc-all-years bge --upload
+create-supply-capacity-mc-all-years utility *extra_args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for year in {{ pjm_capacity_years }}; do
+        echo ">> Generating PJM supply capacity MC: utility={{ utility }} year=${year}" >&2
+        uv run python {{ path_repo }}/utils/data_prep/marginal_costs/generate_supply_capacity_mc.py \
+          --iso pjm \
+          --utility {{ utility }} \
+          --year "${year}" \
+          {{ extra_args }}
+    done
+    echo ">> Done: {{ utility }} all years" >&2
+
+# Generate supply capacity MC for all MD utilities for one year.
+#
+#   just -f md/Justfile create-supply-capacity-mc-all 2025
+# just -f md/Justfile create-supply-capacity-mc-all 2025 --upload
+create-supply-capacity-mc-all year *extra_args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for utility in {{ pjm_utilities }}; do
+        echo ">> Generating PJM supply capacity MC: utility=${utility} year={{ year }}" >&2
+        uv run python {{ path_repo }}/utils/data_prep/marginal_costs/generate_supply_capacity_mc.py \
+          --iso pjm \
+          --utility "${utility}" \
+          --year {{ year }} \
+          {{ extra_args }}
+    done
+    echo ">> Done: all utilities year={{ year }}" >&2
+
+# Generate supply capacity MC for ALL utilities across ALL available years.
+# This is the full backfill. Runs sequentially utility-by-utility, year-by-year.
+#
+#   just -f md/Justfile create-supply-capacity-mc-full-backfill
+# just -f md/Justfile create-supply-capacity-mc-full-backfill --upload
+create-supply-capacity-mc-full-backfill *extra_args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for utility in {{ pjm_utilities }}; do
+        for year in {{ pjm_capacity_years }}; do
+            echo ">> Generating PJM supply capacity MC: utility=${utility} year=${year}" >&2
+            uv run python {{ path_repo }}/utils/data_prep/marginal_costs/generate_supply_capacity_mc.py \
+              --iso pjm \
+              --utility "${utility}" \
+              --year "${year}" \
+              {{ extra_args }}
+        done
+    done
+    echo ">> Done: full backfill" >&2

--- a/tests/test_supply_capacity_pjm.py
+++ b/tests/test_supply_capacity_pjm.py
@@ -1,0 +1,227 @@
+"""Unit tests for PJM RPM supply capacity marginal cost logic.
+
+Tests cover:
+- RPM price selection for a (delivery_year, zone), incl. constrained-LDA zones
+- Calendar-year day-count blend of two overlapping delivery years
+- 5CP hour selection: hour-ending -> hour-beginning conversion, count, season
+- Equal 1/5 allocation and 1 kW recovery validation
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import polars as pl
+import pytest
+
+from utils.data_prep.marginal_costs.supply_capacity_pjm import (
+    _get_rpm_price_per_mw_day,
+    resolve_rpm_price_for_calendar_year,
+    select_5cp_hours,
+    validate_pjm_allocation,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_rpm_df(rows: list[dict]) -> pl.DataFrame:
+    """Build a minimal RPM DataFrame matching the curated parquet schema."""
+    schema = {
+        "delivery_year": pl.String,
+        "dy_start": pl.Date,
+        "zone": pl.String,
+        "final_zonal_capacity_price_per_mw_day": pl.Float64,
+    }
+    return pl.DataFrame(rows, schema=schema)
+
+
+def _make_5cp_df(rows: list[dict]) -> pl.DataFrame:
+    """Build a minimal 5CP DataFrame matching the curated parquet schema."""
+    schema = {
+        "summer_year": pl.Int64,
+        "rank": pl.Int64,
+        "peak_date": pl.Date,
+        "hour_ending_ept": pl.Int64,
+        "zone": pl.String,
+        "mw_unrestricted": pl.Float64,
+    }
+    return pl.DataFrame(rows, schema=schema)
+
+
+def _rpm_row(dy_start_year: int, zone: str, price: float) -> dict:
+    return {
+        "delivery_year": f"{dy_start_year}/{str(dy_start_year + 1)[-2:]}",
+        "dy_start": date(dy_start_year, 6, 1),
+        "zone": zone,
+        "final_zonal_capacity_price_per_mw_day": price,
+    }
+
+
+def _rto_5cp_rows(summer_year: int) -> list[dict]:
+    """Five RTO peak rows for a summer (Jun–Sep), HE18 except rank 4 (HE15)."""
+    specs = [
+        (1, date(summer_year, 6, 23), 18, 160000.0),
+        (2, date(summer_year, 6, 24), 18, 159000.0),
+        (3, date(summer_year, 7, 29), 18, 156000.0),
+        (4, date(summer_year, 6, 25), 15, 152000.0),
+        (5, date(summer_year, 7, 28), 18, 151000.0),
+    ]
+    return [
+        {
+            "summer_year": summer_year,
+            "rank": rank,
+            "peak_date": d,
+            "hour_ending_ept": he,
+            "zone": "RTO",
+            "mw_unrestricted": mw,
+        }
+        for rank, d, he, mw in specs
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _get_rpm_price_per_mw_day
+# ---------------------------------------------------------------------------
+
+
+def test_get_rpm_price_returns_matching_zone_and_year() -> None:
+    rpm_df = _make_rpm_df([_rpm_row(2024, "BGE", 76.755373)])
+    price, dy = _get_rpm_price_per_mw_day(rpm_df, 2024, "BGE")
+    assert price == pytest.approx(76.755373)
+    assert dy == "2024/25"
+
+
+def test_get_rpm_price_selects_constrained_lda_not_rto() -> None:
+    """BGE is a constrained LDA: selecting 'BGE' must not return the RTO price."""
+    rpm_df = _make_rpm_df(
+        [
+            _rpm_row(2025, "RTO", 270.432933),
+            _rpm_row(2025, "BGE", 471.328782),  # constrained, higher
+        ]
+    )
+    price, _ = _get_rpm_price_per_mw_day(rpm_df, 2025, "BGE")
+    assert price == pytest.approx(471.328782)
+
+
+def test_get_rpm_price_raises_when_absent() -> None:
+    rpm_df = _make_rpm_df([_rpm_row(2024, "BGE", 76.0)])
+    with pytest.raises(ValueError, match="No RPM price found"):
+        _get_rpm_price_per_mw_day(rpm_df, 2099, "BGE")
+
+
+# ---------------------------------------------------------------------------
+# resolve_rpm_price_for_calendar_year
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_rpm_day_count_blend_non_leap() -> None:
+    """CY2025 (non-leap): 151 days DY1 + 214 days DY2, MW->kW /1000."""
+    rpm_df = _make_rpm_df(
+        [
+            _rpm_row(2024, "BGE", 100.0),  # DY1 covers Jan 1–May 31 (151 d)
+            _rpm_row(2025, "BGE", 200.0),  # DY2 covers Jun 1–Dec 31 (214 d)
+        ]
+    )
+    result = resolve_rpm_price_for_calendar_year(rpm_df, "BGE", 2025)
+    expected = (100.0 * 151 + 200.0 * 214) / 1000.0  # = 57.9
+    assert result == pytest.approx(expected, abs=1e-9)
+
+
+def test_resolve_rpm_day_count_blend_leap_year() -> None:
+    """CY2024 (leap): Jan–May has 152 days; equal prices -> P*366/1000."""
+    rpm_df = _make_rpm_df(
+        [
+            _rpm_row(2023, "BGE", 100.0),
+            _rpm_row(2024, "BGE", 100.0),
+        ]
+    )
+    result = resolve_rpm_price_for_calendar_year(rpm_df, "BGE", 2024)
+    assert result == pytest.approx(100.0 * 366 / 1000.0, abs=1e-9)
+
+
+def test_resolve_rpm_constant_price_equals_annualized() -> None:
+    """Equal DY prices in a non-leap year recover P*365/1000."""
+    rpm_df = _make_rpm_df(
+        [
+            _rpm_row(2024, "BGE", 150.0),
+            _rpm_row(2025, "BGE", 150.0),
+        ]
+    )
+    result = resolve_rpm_price_for_calendar_year(rpm_df, "BGE", 2025)
+    assert result == pytest.approx(150.0 * 365 / 1000.0, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# select_5cp_hours
+# ---------------------------------------------------------------------------
+
+
+def test_select_5cp_converts_hour_ending_to_hour_beginning() -> None:
+    """HE18 -> hour-beginning 17:00; HE15 -> 14:00."""
+    fivecp_df = _make_5cp_df(_rto_5cp_rows(2025))
+    peaks = select_5cp_hours(fivecp_df, 2025)
+    ts = set(peaks["timestamp"].to_list())
+    assert datetime(2025, 6, 23, 17) in ts  # HE18
+    assert datetime(2025, 6, 25, 14) in ts  # HE15
+    assert peaks.height == 5
+
+
+def test_select_5cp_sorted_and_filters_to_rto() -> None:
+    rows = _rto_5cp_rows(2025) + [
+        {
+            "summer_year": 2025,
+            "rank": 1,
+            "peak_date": date(2025, 6, 23),
+            "hour_ending_ept": 18,
+            "zone": "BGE",  # must be ignored
+            "mw_unrestricted": 6587.7,
+        }
+    ]
+    peaks = select_5cp_hours(_make_5cp_df(rows), 2025)
+    assert peaks.height == 5
+    ts = peaks["timestamp"].to_list()
+    assert ts == sorted(ts)
+
+
+def test_select_5cp_raises_when_not_five_hours() -> None:
+    rows = _rto_5cp_rows(2025)[:4]
+    with pytest.raises(ValueError, match="Expected 5 RTO 5CP hours"):
+        select_5cp_hours(_make_5cp_df(rows), 2025)
+
+
+def test_select_5cp_raises_outside_summer() -> None:
+    rows = _rto_5cp_rows(2025)
+    rows[0]["peak_date"] = date(2025, 1, 15)  # winter — invalid for 5CP
+    with pytest.raises(ValueError, match="outside Jun–Sep"):
+        select_5cp_hours(_make_5cp_df(rows), 2025)
+
+
+# ---------------------------------------------------------------------------
+# Equal allocation + validation
+# ---------------------------------------------------------------------------
+
+
+def test_equal_weight_allocation_sums_to_annual() -> None:
+    fivecp_df = _make_5cp_df(_rto_5cp_rows(2025))
+    peaks = select_5cp_hours(fivecp_df, 2025)
+    annual = 57.9
+    per_hour = annual / 5
+    peak_df = peaks.select("timestamp", pl.lit(per_hour).alias("capacity_cost_per_kw"))
+    assert peak_df.height == 5
+    assert float(peak_df["capacity_cost_per_kw"].sum()) == pytest.approx(annual)
+    # Each of the 5 hours carries an identical share.
+    assert peak_df["capacity_cost_per_kw"].n_unique() == 1
+    validate_pjm_allocation(peak_df, annual)  # should not raise
+
+
+def test_validate_pjm_allocation_fails_for_wrong_sum() -> None:
+    bad_df = pl.DataFrame(
+        {
+            "timestamp": [datetime(2025, 6, 23, 17)],
+            "capacity_cost_per_kw": [1.0],
+        }
+    )
+    with pytest.raises(ValueError, match="PJM validation failed"):
+        validate_pjm_allocation(bad_df, capacity_cost_kw_year=100.0)

--- a/utils/data_prep/marginal_costs/generate_supply_capacity_mc.py
+++ b/utils/data_prep/marginal_costs/generate_supply_capacity_mc.py
@@ -17,10 +17,15 @@ from utils.data_prep.marginal_costs.supply_utils import (
     DEFAULT_ISONE_OUTPUT_S3_BASE,
     DEFAULT_ISONE_ZONE_LOADS_S3_BASE,
     DEFAULT_OUTPUT_S3_BASE,
+    DEFAULT_PJM_5CP_S3_PATH,
+    DEFAULT_PJM_OUTPUT_S3_BASE,
+    DEFAULT_PJM_RPM_S3_PATH,
     DEFAULT_ZONE_LOADS_S3_BASE,
     DEFAULT_ZONE_MAPPING_PATH,
     ISONE_UTILITY_CAPACITY_ZONES,
+    PJM_UTILITY_ZONES,
     VALID_ISONE_UTILITIES,
+    VALID_PJM_UTILITIES,
     VALID_UTILITIES,
     generate_zero_capacity_mc,
     get_utility_mapping,
@@ -35,15 +40,15 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Generate utility-level supply capacity marginal costs from "
-            "NYISO ICAP or ISO-NE FCA."
+            "NYISO ICAP, ISO-NE FCA, or PJM RPM."
         )
     )
     parser.add_argument(
         "--iso",
         type=str,
         default="nyiso",
-        choices=["nyiso", "isone"],
-        help="ISO to use as source: 'nyiso' (default) or 'isone'.",
+        choices=["nyiso", "isone", "pjm"],
+        help="ISO to use as source: 'nyiso' (default), 'isone', or 'pjm'.",
     )
     parser.add_argument(
         "--utility",
@@ -52,7 +57,8 @@ def _parse_args() -> argparse.Namespace:
         help=(
             "Utility short name. NYISO: one of "
             f"{sorted(VALID_UTILITIES)}. "
-            f"ISO-NE: one of {sorted(VALID_ISONE_UTILITIES)}."
+            f"ISO-NE: one of {sorted(VALID_ISONE_UTILITIES)}. "
+            f"PJM (MD): one of {sorted(VALID_PJM_UTILITIES)}."
         ),
     )
     parser.add_argument(
@@ -117,6 +123,28 @@ def _parse_args() -> argparse.Namespace:
             "Defaults to ISONE_UTILITY_CAPACITY_ZONES[utility]."
         ),
     )
+    # PJM-only args
+    parser.add_argument(
+        "--rpm-s3-path",
+        type=str,
+        default=DEFAULT_PJM_RPM_S3_PATH,
+        help=f"[PJM only] S3 path to RPM prices parquet (default: {DEFAULT_PJM_RPM_S3_PATH}).",
+    )
+    parser.add_argument(
+        "--fivecp-s3-path",
+        type=str,
+        default=DEFAULT_PJM_5CP_S3_PATH,
+        help=f"[PJM only] S3 path to 5CP peaks parquet (default: {DEFAULT_PJM_5CP_S3_PATH}).",
+    )
+    parser.add_argument(
+        "--price-zone",
+        type=str,
+        default=None,
+        help=(
+            "[PJM only] RPM price zone (e.g. 'BGE'). "
+            "Defaults to PJM_UTILITY_ZONES[utility]."
+        ),
+    )
     # Shared args
     parser.add_argument(
         "--output-s3-base",
@@ -124,8 +152,9 @@ def _parse_args() -> argparse.Namespace:
         default=None,
         help=(
             "S3 base for output. "
-            f"Defaults to {DEFAULT_OUTPUT_S3_BASE!r} (NYISO) "
-            f"or {DEFAULT_ISONE_OUTPUT_S3_BASE!r} (ISO-NE)."
+            f"Defaults to {DEFAULT_OUTPUT_S3_BASE!r} (NYISO), "
+            f"{DEFAULT_ISONE_OUTPUT_S3_BASE!r} (ISO-NE), "
+            f"or {DEFAULT_PJM_OUTPUT_S3_BASE!r} (PJM)."
         ),
     )
     parser.add_argument(
@@ -153,13 +182,20 @@ def main() -> None:
                 f"Valid choices: {sorted(VALID_UTILITIES)}"
             )
         output_s3_base = args.output_s3_base or DEFAULT_OUTPUT_S3_BASE
-    else:  # isone
+    elif iso == "isone":
         if utility not in VALID_ISONE_UTILITIES:
             raise SystemExit(
                 f"Error: utility {utility!r} is not valid for ISO-NE. "
                 f"Valid choices: {sorted(VALID_ISONE_UTILITIES)}"
             )
         output_s3_base = args.output_s3_base or DEFAULT_ISONE_OUTPUT_S3_BASE
+    else:  # pjm
+        if utility not in VALID_PJM_UTILITIES:
+            raise SystemExit(
+                f"Error: utility {utility!r} is not valid for PJM. "
+                f"Valid choices: {sorted(VALID_PJM_UTILITIES)}"
+            )
+        output_s3_base = args.output_s3_base or DEFAULT_PJM_OUTPUT_S3_BASE
 
     print("=" * 60)
     print(f"SUPPLY CAPACITY MARGINAL COST GENERATION ({iso.upper()})")
@@ -193,7 +229,7 @@ def main() -> None:
                 capacity_load_year if capacity_load_year != price_year else None
             ),
         )
-    else:  # isone
+    elif iso == "isone":
         capacity_zone_id = args.capacity_zone_id or ISONE_UTILITY_CAPACITY_ZONES.get(
             utility
         )
@@ -217,6 +253,29 @@ def main() -> None:
             fca_s3_path=args.fca_s3_path,
             zone_loads_s3_base=DEFAULT_ISONE_ZONE_LOADS_S3_BASE,
             capacity_zone_id=capacity_zone_id,
+        )
+    else:  # pjm
+        price_zone = args.price_zone or PJM_UTILITY_ZONES.get(utility)
+        if price_zone is None:
+            raise SystemExit(
+                f"Error: no price_zone mapping found for utility {utility!r}. "
+                "Provide --price-zone explicitly."
+            )
+        print(f"  Price zone:           {price_zone}")
+        print("=" * 60)
+
+        from utils.data_prep.marginal_costs.supply_capacity_pjm import (
+            compute_supply_capacity_mc_pjm,
+        )
+
+        print("\n── Capacity MC (RPM 5CP) ──")
+        capacity_df = compute_supply_capacity_mc_pjm(
+            utility=utility,
+            year=price_year,
+            storage_options=storage_options,
+            rpm_s3_path=args.rpm_s3_path,
+            fivecp_s3_path=args.fivecp_s3_path,
+            price_zone=price_zone,
         )
 
     capacity_output = prepare_component_output(

--- a/utils/data_prep/marginal_costs/supply_capacity_pjm.py
+++ b/utils/data_prep/marginal_costs/supply_capacity_pjm.py
@@ -1,0 +1,391 @@
+"""Capacity (RPM) marginal cost computation for PJM (Maryland) utility supply MCs.
+
+Methodology
+-----------
+Translate PJM's annual generation-adequacy cost (the Reliability Pricing Model
+Final Zonal Capacity Price) into an hourly capacity cost adder ($/kW per hour)
+concentrated on the five summer coincident-peak (5CP) hours that drive a
+customer's capacity obligation (PLC), then scale to $/MWh via
+prepare_component_output(scale=1000).
+
+See context/domain/marginal_costs/pjm_supply_capacity_marginal_cost.md for the
+full decision record. v1 defaults (BGE):
+
+- Price (A1): Final Zonal Capacity Price for the utility's price zone. The
+  curated RPM dataset already bakes in the locational (LDA) adder, so we select
+  the utility's own zone row (e.g. BGE) — which is a *constrained* LDA in most
+  delivery years — rather than assuming the RTO system price.
+- Annualization (B1) via an exact calendar-year day-count blend of the two
+  overlapping delivery years (PJM DY runs Jun 1 – May 31):
+    DY1 (Jun year-1 – May year) covers Jan 1 – May 31 of the calendar year.
+    DY2 (Jun year   – May year+1) covers Jun 1 – Dec 31 of the calendar year.
+  Because the RPM price is natively $/MW-day, we weight each DY by its actual
+  number of calendar-year days (not a 5/7 month approximation).
+- Peak hours (C1 + D1): the calendar year's own published RTO 5CP hours
+  (Jun 1 – Sep 30).
+- Weights (F1): equal 1/5. PJM defines PLC as the simple *average* of load over
+  the five hours, i.e. each hour carries weight 1/5 (PJM Manual 19 §4.3).
+
+Unit chain:
+  $/MW-day
+  --[day-count blend across two DYs, /1000]--> $/kW-year
+  --[equal split across 5 hours]--> $/kW per peak hour
+  --[x1000 via prepare_component_output]--> $/MWh = capacity_cost_enduse
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import polars as pl
+
+from utils.data_prep.marginal_costs.supply_utils import (
+    DEFAULT_PJM_5CP_S3_PATH,
+    DEFAULT_PJM_RPM_S3_PATH,
+    PJM_UTILITY_ZONES,
+    build_cairo_8760_timestamps,
+)
+
+# Number of summer coincident-peak hours PJM publishes per delivery year.
+N_5CP_HOURS = 5
+
+# ---------------------------------------------------------------------------
+# RPM price loading
+# ---------------------------------------------------------------------------
+
+
+def load_rpm_prices(
+    rpm_s3_path: str,
+    storage_options: dict[str, str],
+) -> pl.DataFrame:
+    """Load curated PJM RPM capacity prices from parquet.
+
+    Schema (see data/pjm/capacity/rpm/):
+        delivery_year                         String  ('2024/25')
+        dy_start, dy_end                      Date
+        zone                                  String  ('BGE', 'PEPCO', ...)
+        lda                                   String
+        bra_price_per_mw_day                  Float64
+        final_zonal_capacity_price_per_mw_day Float64
+        ...
+
+    Returns the full DataFrame (one row per delivery_year x zone).
+    """
+    df = pl.read_parquet(rpm_s3_path, storage_options=storage_options)
+
+    required = {
+        "delivery_year",
+        "dy_start",
+        "zone",
+        "final_zonal_capacity_price_per_mw_day",
+    }
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(f"RPM parquet missing columns: {sorted(missing)}")
+
+    print(f"Loaded RPM prices: {df.height} rows from {rpm_s3_path}")
+    return df
+
+
+def _get_rpm_price_per_mw_day(
+    rpm_df: pl.DataFrame,
+    dy_start_year: int,
+    price_zone: str,
+) -> tuple[float, str]:
+    """Return (final_zonal_capacity_price_per_mw_day, delivery_year) for one DY.
+
+    Selects the row whose delivery year *starts* in ``dy_start_year`` (June 1)
+    for ``price_zone``.
+
+    Raises:
+        ValueError: If no matching (delivery_year, zone) row is found.
+    """
+    rows = rpm_df.filter(
+        (pl.col("dy_start").dt.year() == dy_start_year) & (pl.col("zone") == price_zone)
+    )
+    if rows.is_empty():
+        available = sorted(
+            set(
+                zip(
+                    rpm_df["dy_start"].dt.year().to_list(),
+                    rpm_df["zone"].to_list(),
+                )
+            )
+        )
+        raise ValueError(
+            f"No RPM price found for DY starting {dy_start_year} and zone "
+            f"{price_zone!r}. Available (dy_start_year, zone) pairs: {available}"
+        )
+    price = float(rows["final_zonal_capacity_price_per_mw_day"][0])
+    delivery_year = str(rows["delivery_year"][0])
+    return price, delivery_year
+
+
+def resolve_rpm_price_for_calendar_year(
+    rpm_df: pl.DataFrame,
+    price_zone: str,
+    calendar_year: int,
+) -> float:
+    """Compute capacity_cost_kw_year ($/kW-year) for a calendar year.
+
+    A calendar year spans two PJM delivery years (DY = Jun 1 – May 31):
+      - DY1 (Jun year-1 – May year): covers Jan 1 – May 31 of calendar_year
+      - DY2 (Jun year   – May year+1): covers Jun 1 – Dec 31 of calendar_year
+
+    Because the RPM Final Zonal Capacity Price is natively $/MW-day, each DY is
+    weighted by its actual number of calendar-year days (exact day-count blend),
+    then converted MW -> kW:
+
+        capacity_cost_kw_year =
+            (P_DY1 * days(Jan 1..May 31) + P_DY2 * days(Jun 1..Dec 31)) / 1000
+
+    Args:
+        rpm_df: RPM prices DataFrame (output of load_rpm_prices).
+        price_zone: RPM zone label for the utility (e.g. 'BGE').
+        calendar_year: Calendar year to compute cost for.
+
+    Returns:
+        capacity_cost_kw_year: Total annual capacity cost in $/kW-year.
+    """
+    days_jan_may = (date(calendar_year, 6, 1) - date(calendar_year, 1, 1)).days
+    days_jun_dec = (date(calendar_year + 1, 1, 1) - date(calendar_year, 6, 1)).days
+
+    price_dy1, dy1_label = _get_rpm_price_per_mw_day(
+        rpm_df, calendar_year - 1, price_zone
+    )
+    price_dy2, dy2_label = _get_rpm_price_per_mw_day(rpm_df, calendar_year, price_zone)
+
+    cost_dy1 = price_dy1 * days_jan_may / 1000.0
+    cost_dy2 = price_dy2 * days_jun_dec / 1000.0
+    capacity_cost_kw_year = cost_dy1 + cost_dy2
+
+    print(
+        f"  RPM price resolution for calendar year {calendar_year} "
+        f"(zone {price_zone}):"
+        f"\n    DY1 {dy1_label} (Jan 1–May 31, {days_jan_may} d): "
+        f"${price_dy1:.4f}/MW-day → ${cost_dy1:.4f}/kW"
+        f"\n    DY2 {dy2_label} (Jun 1–Dec 31, {days_jun_dec} d): "
+        f"${price_dy2:.4f}/MW-day → ${cost_dy2:.4f}/kW"
+        f"\n    Total: ${capacity_cost_kw_year:.4f}/kW-year"
+    )
+    return capacity_cost_kw_year
+
+
+# ---------------------------------------------------------------------------
+# 5CP peak-hour selection
+# ---------------------------------------------------------------------------
+
+
+def select_5cp_hours(
+    fivecp_df: pl.DataFrame,
+    summer_year: int,
+) -> pl.DataFrame:
+    """Return the five RTO coincident-peak hours for a summer as hour-beginning ts.
+
+    The 5CP dataset stores hour-*ending* clock hours (``hour_ending_ept``, e.g.
+    18 means the hour ending 18:00, i.e. 17:00–18:00). CAIRO's 8760 grid uses
+    hour-*beginning* naive Eastern timestamps, so the peak hour-beginning is
+    ``peak_date`` at ``hour_ending_ept - 1`` o'clock (HE18 -> 17:00).
+
+    Args:
+        fivecp_df: 5CP peaks DataFrame (see data/pjm/capacity/5cp/).
+        summer_year: Summer (Jun–Sep) whose five RTO peaks to select.
+
+    Returns:
+        DataFrame with columns ``timestamp`` (naive datetime, hour-beginning),
+        ``rank`` (1–5), and ``mw_unrestricted`` (RTO MW), sorted by timestamp.
+
+    Raises:
+        ValueError: If the summer does not have exactly five distinct RTO hours.
+    """
+    required = {"summer_year", "rank", "peak_date", "hour_ending_ept", "zone"}
+    missing = required - set(fivecp_df.columns)
+    if missing:
+        raise ValueError(f"5CP parquet missing columns: {sorted(missing)}")
+
+    peaks = (
+        fivecp_df.filter(
+            (pl.col("zone") == "RTO") & (pl.col("summer_year") == summer_year)
+        )
+        .with_columns(
+            (
+                pl.col("peak_date").cast(pl.Datetime)
+                + pl.duration(hours=pl.col("hour_ending_ept") - 1)
+            ).alias("timestamp")
+        )
+        .select("timestamp", "rank", "mw_unrestricted")
+        .sort("timestamp")
+    )
+
+    if peaks.height != N_5CP_HOURS:
+        raise ValueError(
+            f"Expected {N_5CP_HOURS} RTO 5CP hours for summer {summer_year}, "
+            f"found {peaks.height}. Backfill data/pjm/capacity/5cp/ for that summer."
+        )
+    n_unique = peaks.select(pl.col("timestamp").n_unique()).item()
+    if n_unique != N_5CP_HOURS:
+        raise ValueError(
+            f"5CP hours for summer {summer_year} contain duplicate timestamps "
+            f"({n_unique} unique of {peaks.height})."
+        )
+
+    months = peaks.select(pl.col("timestamp").dt.month()).to_series().to_list()
+    if any(m < 6 or m > 9 for m in months):
+        raise ValueError(
+            f"5CP hours for summer {summer_year} fall outside Jun–Sep: months={months}"
+        )
+
+    print(f"  Selected {peaks.height} RTO 5CP hours for summer {summer_year}:")
+    for ts, rank in zip(
+        peaks["timestamp"].to_list(), peaks["rank"].to_list(), strict=True
+    ):
+        print(f"    rank {rank}: {ts}")
+    return peaks
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate_pjm_allocation(
+    capacity_df: pl.DataFrame,
+    capacity_cost_kw_year: float,
+) -> None:
+    """Validate that a 1 kW constant load recovers the annual RPM cost.
+
+    Sums all hourly capacity_cost_per_kw values and compares to the annual
+    capacity_cost_kw_year. A constant 1 kW load present in every peak hour is
+    allocated its proportional share, so the sum equals the annual cost exactly.
+
+    Raises:
+        ValueError: If the percentage error exceeds 0.01%.
+    """
+    actual_annual = float(capacity_df["capacity_cost_per_kw"].sum())
+    error = abs(actual_annual - capacity_cost_kw_year)
+    error_pct = (
+        (error / capacity_cost_kw_year * 100) if capacity_cost_kw_year > 0 else 0.0
+    )
+
+    print("\n" + "=" * 60)
+    print("VALIDATION: 1 kW Constant Load -> RPM Recovery")
+    print("=" * 60)
+    print(
+        f"  Expected (annual RPM cost):             ${capacity_cost_kw_year:.4f}/kW-yr"
+    )
+    print(f"  Actual (sum of hourly allocations):     ${actual_annual:.4f}/kW-yr")
+    print(f"  Error: ${error:.6f} ({error_pct:.6f}%)")
+
+    tolerance = 0.01
+    if error_pct > tolerance:
+        print("  Validation FAILED")
+        print("=" * 60)
+        raise ValueError(
+            f"PJM validation failed: error {error_pct:.6f}% exceeds {tolerance}%. "
+            f"Expected ${capacity_cost_kw_year:.4f}/kW-yr, got ${actual_annual:.4f}/kW-yr."
+        )
+    print("  Validation PASSED")
+    print("=" * 60)
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestrator
+# ---------------------------------------------------------------------------
+
+
+def compute_supply_capacity_mc_pjm(
+    utility: str,
+    year: int,
+    storage_options: dict[str, str],
+    rpm_s3_path: str = DEFAULT_PJM_RPM_S3_PATH,
+    fivecp_s3_path: str = DEFAULT_PJM_5CP_S3_PATH,
+    price_zone: str | None = None,
+    n_peak_hours: int = N_5CP_HOURS,
+) -> pl.DataFrame:
+    """Compute hourly utility-level PJM supply capacity MC from RPM + 5CP data.
+
+    Args:
+        utility: Utility short name (e.g. 'bge'). Used to look up the default
+            price_zone from PJM_UTILITY_ZONES.
+        year: Calendar year for which to generate the capacity MC.
+        storage_options: AWS storage options for S3 access.
+        rpm_s3_path: S3 path to the curated RPM prices parquet.
+        fivecp_s3_path: S3 path to the curated 5CP peaks parquet.
+        price_zone: RPM zone label (e.g. 'BGE'). Defaults to
+            PJM_UTILITY_ZONES[utility].
+        n_peak_hours: Number of 5CP hours to spread cost over (default 5).
+
+    Returns:
+        DataFrame with columns ``timestamp`` (naive datetime) and
+        ``capacity_cost_per_kw`` ($/kW per hour, nonzero only at the 5CP hours),
+        containing all 8760 hours for the calendar year (non-peak hours = 0.0).
+    """
+    if price_zone is None:
+        if utility not in PJM_UTILITY_ZONES:
+            raise ValueError(
+                f"No default price_zone for utility {utility!r}. "
+                f"Provide price_zone explicitly or add to PJM_UTILITY_ZONES."
+            )
+        price_zone = PJM_UTILITY_ZONES[utility]
+
+    print(f"  Utility:             {utility}")
+    print(f"  Calendar year:       {year}")
+    print(f"  Price zone:          {price_zone}")
+    print(f"  Peak hours (5CP):    {n_peak_hours}")
+
+    # 1. Resolve blended annual capacity cost for the calendar year.
+    print("\n── RPM Prices ──")
+    rpm_df = load_rpm_prices(rpm_s3_path, storage_options)
+    print("\n── RPM Price Resolution ──")
+    capacity_cost_kw_year = resolve_rpm_price_for_calendar_year(
+        rpm_df=rpm_df,
+        price_zone=price_zone,
+        calendar_year=year,
+    )
+
+    # 2. Select the calendar year's own summer 5CP hours.
+    print(f"\n── 5CP Hour Selection (summer {year}) ──")
+    fivecp_df = pl.read_parquet(fivecp_s3_path, storage_options=storage_options)
+    peaks = select_5cp_hours(fivecp_df, summer_year=year)
+
+    # 3. Equal 1/K allocation (PLC = average over the five hours).
+    per_hour_cost = capacity_cost_kw_year / n_peak_hours
+    peak_hours_df = peaks.select(
+        "timestamp", pl.lit(per_hour_cost).alias("capacity_cost_per_kw")
+    )
+    print(
+        f"\n  Equal-weight allocation: ${capacity_cost_kw_year:.4f}/kW-yr / "
+        f"{n_peak_hours} = ${per_hour_cost:.4f}/kW on each 5CP hour"
+    )
+
+    # 4. Validate 1-kW constant-load recovery.
+    validate_pjm_allocation(peak_hours_df, capacity_cost_kw_year)
+
+    # 5. Expand to the full 8760-hour grid, filling non-peak hours with 0.0.
+    print("\n── Expanding to Full 8760 Hours ──")
+    ref_8760 = build_cairo_8760_timestamps(year)
+    capacity_df = (
+        ref_8760.join(peak_hours_df, on="timestamp", how="left")
+        .with_columns(pl.col("capacity_cost_per_kw").fill_null(0.0))
+        .sort("timestamp")
+    )
+    n_peaks_placed = capacity_df.filter(pl.col("capacity_cost_per_kw") > 0).height
+    if n_peaks_placed != n_peak_hours:
+        raise ValueError(
+            f"Placed {n_peaks_placed} nonzero peak hours on the 8760 grid, "
+            f"expected {n_peak_hours}. A 5CP timestamp may not align to the "
+            f"Cairo grid (check DST / leap-year handling)."
+        )
+    print(f"  Placed {n_peaks_placed} peak hours on {capacity_df.height} total hours")
+
+    n_rows = capacity_df.height
+    n_unique = capacity_df.select(pl.col("timestamp").n_unique()).item()
+    if n_rows != 8760:
+        raise ValueError(f"Capacity MC DataFrame has {n_rows} rows, expected 8760.")
+    if n_rows != n_unique:
+        raise ValueError(
+            f"Capacity MC DataFrame has {n_rows} rows but {n_unique} unique "
+            f"timestamps. Duplicate timestamps detected."
+        )
+
+    return capacity_df

--- a/utils/data_prep/marginal_costs/supply_utils.py
+++ b/utils/data_prep/marginal_costs/supply_utils.py
@@ -87,6 +87,12 @@ DEFAULT_ISONE_BULK_TX_OUTPUT_S3_BASE = (
 DEFAULT_PJM_LMP_S3_BASE = PJM_LMP_S3_BASE
 DEFAULT_PJM_OUTPUT_S3_BASE = "s3://data.sb/switchbox/marginal_costs/md/supply/"
 
+# Curated PJM capacity reference datasets (see data/pjm/capacity/{rpm,5cp}/).
+# RPM: BRA + Final Zonal Capacity Prices per (delivery_year, zone), $/MW-day.
+# 5CP: the five summer coincident-peak hours per summer_year (RTO + per-zone MW).
+DEFAULT_PJM_RPM_S3_PATH = "s3://data.sb/pjm/capacity/rpm/data.parquet"
+DEFAULT_PJM_5CP_S3_PATH = "s3://data.sb/pjm/capacity/5cp/data.parquet"
+
 # Maps each MD utility slug (canonical std_name from utils/utility_codes.py) to
 # its PJM zone aggregate pnode_name. Co-ops and municipals that sit inside an IOU
 # zone share that IOU's zone LMP. Keep this set in sync with the registered MD


### PR DESCRIPTION
## Overview

Adds the PJM supply **capacity** marginal-cost pipeline (last-mile compute for MD/BGE). `generate_supply_capacity_mc.py` now supports `--iso pjm`, backed by a new `supply_capacity_pjm.py` that turns the curated RPM Final Zonal Capacity Price + published summer 5CP hours into an 8760-row `capacity_cost_enduse` (`$/MWh`) parquet. Supply energy for PJM already shipped; this is capacity only.

The BGE 2025 output is live at `s3://data.sb/switchbox/marginal_costs/md/supply/capacity/utility=bge/year=2025/data.parquet` (blended annual `$112.45/kW-yr` placed on the 5 summer-2025 5CP hours; 1 kW recovery validates exactly).

## Method (v1 defaults, per the methodology doc)

- **Price (A1):** Final Zonal Capacity Price for the utility's **own zone row** — which carries the constrained-LDA price (BGE is a constrained LDA in 6 of 9 DYs, incl. both DYs feeding CY2025). We do not assume the RTO system price.
- **Annualization (B1):** exact **day-count** blend of the two overlapping delivery years. PJM's price is `$/MW-day`, so each DY is weighted by its actual calendar-year days (151/152 + 214), `/1000` for MW→kW — not ISO-NE's month shape.
- **Peak hours (C1+D1):** the calendar year's own published RTO 5CP hours (Jun–Sep).
- **Weights (F1):** equal 1/5 (PLC = average over the five hours).

## Reviewer focus

- **Which price sits on the 5CP hours:** I use the calendar-year *blended* `$/kW-yr` (parallels the RI/ISO-NE template). The alternative is the owning DY's price only (DY2025/26) — flagged in the doc as a causation-vs-consistency call worth a sanity check.
- **Hour-ending → hour-beginning conversion:** 5CP stores hour-ending (HE18); CAIRO's grid is hour-beginning, so peaks land at HE−1 (HE18→17:00). Covered by tests.
- **Doc corrections:** I corrected three things the methodology doc had wrong/loose — the "BGE clears at RTO" claim, the DY blend units, and the §12 checklist.

## Tests

`tests/test_supply_capacity_pjm.py` (12): constrained-LDA zone selection, day-count blend incl. leap year, HE conversion, count/season guards, equal-weight sum, 1 kW validation. `just check` clean; existing ISO-NE capacity tests still pass.

Closes #469

Made with [Cursor](https://cursor.com)