### PR TITLE
Zero out municipal utilities from assignment in MD

### DIFF
--- a/context/code/data/utility_assignment_resstock.md
+++ b/context/code/data/utility_assignment_resstock.md
@@ -180,17 +180,28 @@ County polygons cover all of Maryland's land area by definition, so the electric
 
 Gas coverage gaps remain (HIFLD gas boundaries still have the same rural/suburban gaps as before), so the nearest-neighbor fill is genuinely needed for gas, with the same behavior as documented in the previous HIFLD-based approach.
 
-### No excluded gas utilities
+### Excluded gas utilities
 
-`excluded_gas_utilities` is not set for MD. All gas LDCs are assigned; none are zeroed before sampling.
+`excluded_gas_utilities` for MD (in `state_configs.yaml`):
 
-### State_configs.yaml kwargs for MD
+- `easton_muni` — Easton Utilities municipal gas LDC; too small for ResStock
+  rate-design sampling. Still present in `utility_codes.py` (tariffs, EIA IDs,
+  HIFLD names). Assignment zeros its PUMA gas probability and renormalizes;
+  donor-PUMA fill applies if a PUMA would otherwise have no gas utility left.
+
+### State_configs.yaml for MD
 
 ```yaml
-state_crs: 2248
-puma_year: 2019
-electric_service_territory_s3_path: "s3://data.sb/eia/861/service_territory/state=MD/data.parquet"
-gas_poly_filename: "md_gas_utilities_20260605.csv"
+MD:
+  state_fips: "24"
+  add_vulnerability_columns: false
+  utility_assignment:
+    module: data.resstock.utility.assign_utility_md
+    kwargs:
+      state_crs: 2248
+      puma_year: 2019
+      excluded_gas_utilities:
+        - easton_muni
 ```
 
 ### Full MD pipeline (start to finish)

--- a/context/code/data/utility_assignment_resstock.md
+++ b/context/code/data/utility_assignment_resstock.md
@@ -13,22 +13,29 @@ How electric and gas utilities are assigned to ResStock buildings — generic ar
 - **Inputs:** ResStock metadata (with `in.puma`, `in.heating_fuel`, `has_natgas_connection`), electric and gas utility service-territory polygons (CSV with WKT), Census PUMAs (pygris).
 - **Outputs:** Same metadata with `sb.electric_utility` and `sb.gas_utility` added (or overwritten).
 - **Logic:** PUMA–utility overlap → PUMA-level probability tables → per-building sampling (deterministic seed). Electric: every building gets an electric utility. Gas: only buildings with `has_natgas_connection` get a gas utility; others get null.
-- **Generic functions:** `create_hh_utilities()`, `zero_excluded_gas_utilities_and_renormalize()`, `fill_missing_puma_probabilities()`, `calculate_puma_utility_overlap()`, `calculate_utility_probabilities()`, `calculate_prior_distributions()`, `sample_utility_per_building()`, `print_comparison_summary()`, `puma_id_series_for_join()`, `read_csv_to_gdf_from_s3()` all live in `data/resstock/utility/utils.py` and are state-generic.
+- **Generic functions:** `create_hh_utilities()`, `zero_excluded_utilities_and_renormalize()`, `fill_missing_puma_probabilities()`, `calculate_puma_utility_overlap()`, `calculate_utility_probabilities()`, `calculate_prior_distributions()`, `sample_utility_per_building()`, `print_comparison_summary()`, `puma_id_series_for_join()`, `read_csv_to_gdf_from_s3()` all live in `data/resstock/utility/utils.py` and are state-generic.
 
 ---
 
-## Excluded gas utilities
+## Excluded utilities (gas and electric)
 
-A fixed set of **excluded gas utilities** are excluded from assignment: their prior probability is set to zero before sampling.
+A fixed set of **excluded utilities** can be dropped from assignment: their prior
+probability is set to zero before sampling.
 
-- **Constant:** `EXCLUDED_GAS_UTILITIES` in `assign_utility_ny.py` (loaded from `data/resstock/state_configs.yaml` → `NY.utility_assignment.kwargs.excluded_gas_utilities`):
-  - `bath`, `chautauqua`, `corning`, `fillmore`, `reserve`, `stlaw`
-- **Rationale:** These utilities have very few customers; we do not assign ResStock buildings to them for rate-design/BAT purposes.
-- **Implementation:** `zero_excluded_gas_utilities_and_renormalize()` (in `data/resstock/utility/utils.py`), called from `create_hh_utilities()` when `excluded_gas_utilities` is non-empty:
+- **Config:** `excluded_gas_utilities` and/or `excluded_electric_utilities` under
+  `data/resstock/state_configs.yaml` → `<STATE>.utility_assignment.kwargs`.
+- **NY gas example:** `bath`, `chautauqua`, `corning`, `fillmore`, `reserve`, `stlaw`
+  (loaded in `assign_utility_ny.py` as `EXCLUDED_GAS_UTILITIES`).
+- **Rationale:** These utilities have very few customers; we do not assign ResStock
+  buildings to them for rate-design/BAT purposes. They remain in `utility_codes.py`.
+- **Implementation:** `zero_excluded_utilities_and_renormalize()` (in
+  `data/resstock/utility/utils.py`), invoked when the
+  corresponding exclude list is non-empty:
   1. Set to 0 the probability columns whose name is in `excluded_utilities`.
-  2. For each PUMA row, if the remaining (non-excluded) gas probabilities sum to zero, the PUMA is "bad" and must be handled (see below).
-  3. Otherwise, renormalize each row so gas probabilities sum to 1.
-  4. Final gas probability table is used by `sample_utility_per_building(..., only_when_fuel="Natural Gas")`.
+  2. For each PUMA row, if the remaining probabilities sum to zero, the PUMA is
+     "bad" and must be handled (see below).
+  3. Otherwise, renormalize each row so probabilities sum to 1.
+  4. Final probability table is used by `sample_utility_per_building`.
 
 ---
 
@@ -36,7 +43,7 @@ A fixed set of **excluded gas utilities** are excluded from assignment: their pr
 
 If, for a given PUMA, **all** gas probability was in excluded utilities, then after zeroing that PUMA has no gas utility left. Two behaviors:
 
-1. **`pumas` not provided:** `zero_excluded_gas_utilities_and_renormalize(..., pumas=None)` raises `ValueError` with the affected `puma_id`(s).
+1. **`pumas` not provided:** `zero_excluded_utilities_and_renormalize(..., pumas=None)` raises `ValueError` with the affected `puma_id`(s).
 2. **`pumas` provided (GeoDataFrame):** A **donor** PUMA is chosen and its gas probability row is used for the bad PUMA.
    - **Donor selection:** Prefer a **good** PUMA (non-zero gas probability after exclusion) that is **adjacent** to the bad PUMA (geometries touch). Among adjacent good PUMAs, choose the one whose centroid is closest to the bad PUMA's centroid. If no adjacent good PUMA exists, use the good PUMA with the nearest centroid (fallback).
    - **Result:** The bad PUMA's row is replaced by the donor's gas probability row; then all rows are renormalized so each sums to 1.
@@ -52,7 +59,7 @@ PUMA identifiers can appear as integers or strings (e.g. `100` vs `"00100"`). Fo
   - If `PUMACE10` exists: `pumas["PUMACE10"].astype(str).str.zfill(5)`.
   - Else if `GEOID` exists: last 5 characters of `GEOID`.
   - Else `None`.
-- Bad/donor PUMA matching in `zero_excluded_gas_utilities_and_renormalize` uses this normalization (e.g. `str(bad_puma_id).zfill(5)`) so that geometry lookups and probability row replacement are consistent.
+- Bad/donor PUMA matching in `zero_excluded_utilities_and_renormalize` uses this normalization (e.g. `str(bad_puma_id).zfill(5)`) so that geometry lookups and probability row replacement are consistent.
 
 ---
 
@@ -81,7 +88,7 @@ After zeroing excluded gas utilities (and optionally replacing bad-PUMA rows wit
 
 - `EXCLUDED_GAS_UTILITIES` constant (loaded from `state_configs.yaml`).
 - `puma_id_series_for_join` (PUMACE10, GEOID, missing columns).
-- `zero_excluded_gas_utilities_and_renormalize`: no excluded cols (unchanged); zero + renormalize; bad PUMA with `pumas=None` (raises); bad PUMA with `pumas` and touching geometries (donor used, row sums to 1).
+- `zero_excluded_utilities_and_renormalize`: no excluded cols (unchanged); zero + renormalize; bad PUMA with `pumas=None` (raises); bad PUMA with `pumas` and touching geometries (donor used, row sums to 1).
 - Other helpers: `calculate_utility_probabilities`, `calculate_prior_distributions`, `sample_utility_per_building` (determinism, gas only when `has_natgas_connection`, etc.).
 
 ---
@@ -189,6 +196,16 @@ Gas coverage gaps remain (HIFLD gas boundaries still have the same rural/suburba
   HIFLD names). Assignment zeros its PUMA gas probability and renormalizes;
   donor-PUMA fill applies if a PUMA would otherwise have no gas utility left.
 
+### Excluded electric utilities
+
+`excluded_electric_utilities` for MD (same zero + renormalize / donor-PUMA
+mechanism as gas, via `zero_excluded_utilities_and_renormalize(..., label="electric")`):
+
+- `berlin_muni`
+- `hagerstown_muni`
+- `easton_muni`
+- `somerset_rec`
+
 ### State_configs.yaml for MD
 
 ```yaml
@@ -202,6 +219,11 @@ MD:
       puma_year: 2019
       excluded_gas_utilities:
         - easton_muni
+      excluded_electric_utilities:
+        - berlin_muni
+        - hagerstown_muni
+        - easton_muni
+        - somerset_rec
 ```
 
 ### Full MD pipeline (start to finish)
@@ -264,6 +286,8 @@ XX:
       gas_poly_filename: xx_gas_utilities_YYYYMMDD.csv
       excluded_gas_utilities:    # optional — gas utility names to zero before sampling
         - smallutil1
+      excluded_electric_utilities:  # optional — electric utility names to zero
+        - smallmuni1
 ```
 
 **How `SUPPORTED_UTILITY_STATES` is derived:** `assign_utility.py` reads `state_configs.yaml` at import time and includes every state whose entry contains a `utility_assignment` key. Adding the key is enough; no manual set update is needed.

--- a/data/resstock/state_configs.yaml
+++ b/data/resstock/state_configs.yaml
@@ -76,6 +76,13 @@ MD:
       # renormalized (donor PUMA if a row would go all-zero).
       excluded_gas_utilities:
         - easton_muni
+      # Small electric municipals + Somerset REC excluded from assignment
+      # (same zero + renormalize / donor-PUMA pattern as gas).
+      excluded_electric_utilities:
+        - berlin_muni
+        - hagerstown_muni
+        - easton_muni
+        - somerset_rec
 CT:
   state_fips: "09"
   add_vulnerability_columns: false

--- a/data/resstock/state_configs.yaml
+++ b/data/resstock/state_configs.yaml
@@ -70,6 +70,12 @@ MD:
       # MD uses national HIFLD shapefiles (not per-state CSVs).  Valid
       # utilities are defined in utils/utility_codes.py and filtered at
       # assignment time via filter_hifld_for_state().
+      # Small municipal gas LDC excluded from building assignment (same
+      # pattern as NY excluded_gas_utilities). Remains in utility_codes.py
+      # for tariffs / EIA / zone mapping; PUMA probabilities are zeroed and
+      # renormalized (donor PUMA if a row would go all-zero).
+      excluded_gas_utilities:
+        - easton_muni
 CT:
   state_fips: "09"
   add_vulnerability_columns: false

--- a/data/resstock/utility/assign_utility_ct.py
+++ b/data/resstock/utility/assign_utility_ct.py
@@ -64,7 +64,7 @@ from data.resstock.utility.utils import (
     load_pumas,
     print_comparison_summary,
     sample_utility_per_building,
-    zero_excluded_gas_utilities_and_renormalize,
+    zero_excluded_utilities_and_renormalize,
 )
 
 # ── CT-specific constants ─────────────────────────────────────────────────────
@@ -209,11 +209,12 @@ def assign_utility_ct(
     puma_gas_probs = fill_missing_puma_probabilities(puma_gas_probs, pumas, label="gas")
 
     if excluded_gas_utilities:
-        puma_gas_probs = zero_excluded_gas_utilities_and_renormalize(
+        puma_gas_probs = zero_excluded_utilities_and_renormalize(
             puma_gas_probs,
             excluded_utilities=excluded_gas_utilities,
             pumas=pumas,
             puma_and_heating_fuel=puma_and_heating_fuel,
+            label="gas",
         )
 
     building_elec = sample_utility_per_building(

--- a/data/resstock/utility/assign_utility_md.py
+++ b/data/resstock/utility/assign_utility_md.py
@@ -50,7 +50,7 @@ from data.resstock.utility.utils import (
     load_pumas,
     print_comparison_summary,
     sample_utility_per_building,
-    zero_excluded_gas_utilities_and_renormalize,
+    zero_excluded_utilities_and_renormalize,
 )
 
 # ── MD-specific constants ─────────────────────────────────────────────────────
@@ -72,6 +72,7 @@ def assign_utility(
     state_crs: int,
     puma_year: int,
     excluded_gas_utilities: list[str] | None = None,
+    excluded_electric_utilities: list[str] | None = None,
     puma_cache_dir: str | None = None,
     hifld_cache_dir: str | None = None,
     **_kwargs: object,
@@ -88,6 +89,8 @@ def assign_utility(
         puma_year: Census TIGER/Line PUMA vintage year (2019 for 2010-def).
         excluded_gas_utilities: Standardised gas utility names whose PUMA
             probabilities are zeroed before sampling (default: none).
+        excluded_electric_utilities: Standardised electric utility names
+            whose PUMA probabilities are zeroed before sampling (default: none).
         puma_cache_dir: Root local directory for the PUMA shapefile cache.
             Defaults to ``paths.gis_cache_dir`` in ``config.yaml``.
         hifld_cache_dir: Root local directory for national HIFLD parquets.
@@ -124,6 +127,9 @@ def assign_utility(
         excluded_gas_utilities=frozenset(excluded_gas_utilities)
         if excluded_gas_utilities is not None
         else frozenset(),
+        excluded_electric_utilities=frozenset(excluded_electric_utilities)
+        if excluded_electric_utilities is not None
+        else frozenset(),
     )
 
 
@@ -137,6 +143,7 @@ def assign_utility_md(
     pumas: gpd.GeoDataFrame,
     state_crs: int,
     excluded_gas_utilities: frozenset[str] = frozenset(),
+    excluded_electric_utilities: frozenset[str] = frozenset(),
 ) -> pl.LazyFrame:
     """Assign electric and gas utilities to ResStock buildings in MD.
 
@@ -155,6 +162,8 @@ def assign_utility_md(
         state_crs: EPSG code for the MD projected CRS.
         excluded_gas_utilities: Gas utility names whose PUMA probabilities
             are zeroed before sampling (default: empty).
+        excluded_electric_utilities: Electric utility names whose PUMA
+            probabilities are zeroed before sampling (default: empty).
 
     Returns:
         LazyFrame with all original metadata columns plus
@@ -194,12 +203,22 @@ def assign_utility_md(
     )
     puma_gas_probs = fill_missing_puma_probabilities(puma_gas_probs, pumas, label="gas")
 
+    if excluded_electric_utilities:
+        puma_elec_probs = zero_excluded_utilities_and_renormalize(
+            puma_elec_probs,
+            excluded_utilities=excluded_electric_utilities,
+            pumas=pumas,
+            puma_and_heating_fuel=puma_and_heating_fuel,
+            label="electric",
+        )
+
     if excluded_gas_utilities:
-        puma_gas_probs = zero_excluded_gas_utilities_and_renormalize(
+        puma_gas_probs = zero_excluded_utilities_and_renormalize(
             puma_gas_probs,
             excluded_utilities=excluded_gas_utilities,
             pumas=pumas,
             puma_and_heating_fuel=puma_and_heating_fuel,
+            label="gas",
         )
 
     building_elec = sample_utility_per_building(

--- a/data/resstock/utility/utils.py
+++ b/data/resstock/utility/utils.py
@@ -835,71 +835,79 @@ def fill_missing_puma_probabilities(
     return pl.concat([probs_df, pl.concat(new_rows)]).lazy()
 
 
-def zero_excluded_gas_utilities_and_renormalize(
-    puma_gas_probs: pl.LazyFrame,
+def zero_excluded_utilities_and_renormalize(
+    puma_probs: pl.LazyFrame,
     excluded_utilities: frozenset[str],
     pumas: gpd.GeoDataFrame | None = None,
     puma_and_heating_fuel: pl.LazyFrame | None = None,
+    *,
+    label: str = "gas",
 ) -> pl.LazyFrame:
-    """Set prior probability to zero for excluded gas utilities; renormalize.
+    """Set prior probability to zero for excluded utilities; renormalize.
 
-    For each PUMA row, columns corresponding to *excluded_utilities* are set
-    to 0, then the row is renormalized so probabilities sum to 1.  If any PUMA
-    would have all gas utilities zeroed (no gas utility left with positive
-    probability), either raises ``ValueError`` (when *pumas* is ``None``) or
-    uses the nearest-neighbor PUMA's gas probability distribution (when *pumas*
-    is provided).  When *puma_and_heating_fuel* is provided, prints how many
-    gas buildings (``has_natgas_connection``) are in each affected PUMA.
+    Works for either electric or gas probability tables.  For each PUMA row,
+    columns in *excluded_utilities* are set to 0, then the row is renormalized
+    so probabilities sum to 1.  If any PUMA would have all utilities zeroed,
+    either raises ``ValueError`` (when *pumas* is ``None``) or uses the
+    nearest-neighbor PUMA's probability distribution (when *pumas* is
+    provided).
+
+    When *puma_and_heating_fuel* is provided, debug output includes building
+    counts per affected PUMA: for ``label="gas"`` only
+    ``has_natgas_connection`` buildings are counted; for ``label="electric"``
+    all buildings in the PUMA are counted.
 
     Args:
-        puma_gas_probs: Wide-format LazyFrame with ``puma_id`` and gas
-            utility probability columns.
-        excluded_utilities: Set of utility column names whose prior
-            probability should be zeroed.
-        pumas: Census PUMA GeoDataFrame (needed for nearest-neighbor
-            donor resolution).
+        puma_probs: Wide-format LazyFrame with ``puma_id`` and one probability
+            column per utility.
+        excluded_utilities: Utility column names whose prior probability
+            should be zeroed.
+        pumas: Census PUMA GeoDataFrame (needed for nearest-neighbor donor
+            resolution).
         puma_and_heating_fuel: LazyFrame with ``bldg_id``, ``puma``,
             ``heating_fuel``, ``has_natgas_connection`` (for debug counts).
+        label: ``"gas"`` or ``"electric"`` — used in log/error messages and
+            to select the building-count filter.
     """
-    gas_probs_df = cast(pl.DataFrame, puma_gas_probs.collect())
-    utility_cols = [c for c in gas_probs_df.columns if c != "puma_id"]
+    probs_df = cast(pl.DataFrame, puma_probs.collect())
+    utility_cols = [c for c in probs_df.columns if c != "puma_id"]
     excluded_cols = [c for c in utility_cols if c in excluded_utilities]
 
     if not excluded_cols:
-        return puma_gas_probs
+        return puma_probs
 
-    gas_probs_df_before_zero = gas_probs_df.clone()
+    probs_df_before_zero = probs_df.clone()
 
-    gas_probs_df = gas_probs_df.with_columns(
-        [pl.lit(0.0).alias(c) for c in excluded_cols]
-    )
+    probs_df = probs_df.with_columns([pl.lit(0.0).alias(c) for c in excluded_cols])
 
-    row_sums = gas_probs_df.select(pl.sum_horizontal(utility_cols)).to_series()
-    gas_probs_df = gas_probs_df.with_columns(row_sums.alias("_row_sum"))
+    row_sums = probs_df.select(pl.sum_horizontal(utility_cols)).to_series()
+    probs_df = probs_df.with_columns(row_sums.alias("_row_sum"))
     bad_mask = row_sums == 0
 
     if bad_mask.any():
-        bad_puma_ids = gas_probs_df.filter(bad_mask)["puma_id"].to_list()
+        bad_puma_ids = probs_df.filter(bad_mask)["puma_id"].to_list()
         if pumas is None:
             raise ValueError(
-                "Zero gas probability for all utilities in PUMA(s) after excluding "
-                f"excluded gas utilities {sorted(excluded_utilities)}. Affected puma_id(s): {bad_puma_ids}. "
-                "Excluding these utilities leaves no gas utility with positive probability."
+                f"Zero {label} probability for all utilities in PUMA(s) after excluding "
+                f"excluded {label} utilities {sorted(excluded_utilities)}. "
+                f"Affected puma_id(s): {bad_puma_ids}. "
+                f"Excluding these utilities leaves no {label} utility with positive "
+                "probability."
             )
 
-        gas_bldg_counts: dict[str, int] = {}
+        bldg_counts: dict[str, int] = {}
         if puma_and_heating_fuel is not None:
+            counts_lf = puma_and_heating_fuel
+            if label == "gas":
+                counts_lf = counts_lf.filter(pl.col("has_natgas_connection"))
             counts_df = cast(
                 pl.DataFrame,
-                puma_and_heating_fuel.filter(pl.col("has_natgas_connection"))
-                .group_by("puma")
-                .agg(pl.len().alias("n_bldgs"))
-                .collect(),
+                counts_lf.group_by("puma").agg(pl.len().alias("n_bldgs")).collect(),
             )
             for row in counts_df.iter_rows(named=True):
                 puma_val = row["puma"]
                 key = str(puma_val).zfill(5) if puma_val is not None else ""
-                gas_bldg_counts[key] = int(row["n_bldgs"])
+                bldg_counts[key] = int(row["n_bldgs"])
 
         puma_id_in_pumas = puma_id_series_for_join(pumas)
         if puma_id_in_pumas is None:
@@ -909,11 +917,11 @@ def zero_excluded_gas_utilities_and_renormalize(
         pumas = pumas.copy()
         pumas["_puma_id"] = puma_id_in_pumas.values
 
-        good_df = gas_probs_df.filter(~bad_mask)
+        good_df = probs_df.filter(~bad_mask)
         good_puma_ids = good_df["puma_id"].to_list()
         if not good_puma_ids:
             raise ValueError(
-                "No PUMA has non-zero gas probability after excluding small utilities; "
+                f"No PUMA has non-zero {label} probability after excluding utilities; "
                 "cannot assign nearest neighbor."
             )
 
@@ -966,9 +974,7 @@ def zero_excluded_gas_utilities_and_renormalize(
                     if d < best_dist:
                         best_dist = d
                         best_donor = good_str
-                nn_note = (
-                    "no adjacent PUMA with gas; using nearest by centroid (fallback)"
-                )
+                nn_note = f"no adjacent PUMA with {label}; using nearest by centroid (fallback)"
 
             if best_donor is None:
                 raise ValueError(f"No donor PUMA found for bad PUMA {bad_puma_id!r}.")
@@ -994,15 +1000,15 @@ def zero_excluded_gas_utilities_and_renormalize(
                 )
             )
 
-            orig_row_df = gas_probs_df_before_zero.filter(
+            orig_row_df = probs_df_before_zero.filter(
                 pl.col("puma_id").cast(pl.Utf8).str.zfill(5) == bad_str
             )
             if orig_row_df.height == 0:
-                orig_row_df = gas_probs_df_before_zero.filter(
+                orig_row_df = probs_df_before_zero.filter(
                     pl.col("puma_id").cast(pl.Utf8) == bad_str
                 )
             if orig_row_df.height == 0:
-                orig_row_df = gas_probs_df_before_zero.filter(
+                orig_row_df = probs_df_before_zero.filter(
                     pl.col("puma_id") == bad_puma_id
                 )
             orig_vals = (
@@ -1032,15 +1038,21 @@ def zero_excluded_gas_utilities_and_renormalize(
             )
             row_sum_before = sum(orig_probs.get(u, 0) for u in utility_cols)
 
-            n_bldgs = gas_bldg_counts.get(bad_str, 0)
-            print(
-                f"PUMA {bad_puma_id!r} had zero gas probability "
-                f"after excluding utilities; using donor PUMA {best_donor!r} "
-                f"({nn_note}; distance={best_dist:.0f} m). "
-                f"Affected bldg_ids (gas buildings in this PUMA): {n_bldgs}."
+            n_bldgs = bldg_counts.get(bad_str, 0)
+            bldg_desc = (
+                "gas buildings in this PUMA"
+                if label == "gas"
+                else "buildings in this PUMA"
             )
             print(
-                f"  Excluded gas utilities zeroed in this PUMA: {excluded_that_had_prob}; "
+                f"PUMA {bad_puma_id!r} had zero {label} probability "
+                f"after excluding utilities; using donor PUMA {best_donor!r} "
+                f"({nn_note}; distance={best_dist:.0f} m). "
+                f"Affected bldg_ids ({bldg_desc}): {n_bldgs}."
+            )
+            print(
+                f"  Excluded {label} utilities zeroed in this PUMA: "
+                f"{excluded_that_had_prob}; "
                 f"their prior probs before removal: {small_probs_before}."
             )
             print(
@@ -1050,20 +1062,20 @@ def zero_excluded_gas_utilities_and_renormalize(
                 u for u in utility_cols if orig_probs.get(u, 0) > 0
             ):
                 print(
-                    "  → So before the fix, all gas bldg_ids in this PUMA would have been "
+                    f"  → So before the fix, all {label} bldg_ids in this PUMA would have been "
                     f"assigned to one of {excluded_that_had_prob}."
                 )
             print(f"  After nearest-neighbor approximation: {after_nn_str}")
 
-        gas_probs_df = pl.concat([good_df, pl.concat(fixed_rows)])
+        probs_df = pl.concat([good_df, pl.concat(fixed_rows)])
 
-    gas_probs_df = gas_probs_df.drop("_row_sum")
+    probs_df = probs_df.drop("_row_sum")
 
-    row_sums = gas_probs_df.select(pl.sum_horizontal(utility_cols)).to_series()
-    gas_probs_df = gas_probs_df.with_columns(
+    row_sums = probs_df.select(pl.sum_horizontal(utility_cols)).to_series()
+    probs_df = probs_df.with_columns(
         [(pl.col(c) / row_sums).alias(c) for c in utility_cols]
     )
-    return gas_probs_df.lazy()
+    return probs_df.lazy()
 
 
 # ---------------------------------------------------------------------------
@@ -1079,6 +1091,7 @@ def create_hh_utilities(
     utility_name_map: pl.LazyFrame,
     state_crs: int,
     excluded_gas_utilities: frozenset[str] = frozenset(),
+    excluded_electric_utilities: frozenset[str] = frozenset(),
     fill_missing_pumas: bool = False,
 ) -> pl.LazyFrame:
     """Create a LazyFrame of households with their associated utilities.
@@ -1098,6 +1111,8 @@ def create_hh_utilities(
         state_crs: EPSG code of the projected CRS for area calculations.
         excluded_gas_utilities: Gas utility names whose prior probability
             should be zeroed before sampling (default: empty).
+        excluded_electric_utilities: Electric utility names whose prior
+            probability should be zeroed before sampling (default: empty).
         fill_missing_pumas: When ``True``, PUMAs with no utility polygon
             coverage (absent from the overlap table) are filled using the
             nearest covered PUMA's distribution.  Use for states where the
@@ -1131,12 +1146,22 @@ def create_hh_utilities(
             puma_gas_probs, pumas, label="gas"
         )
 
+    if excluded_electric_utilities:
+        puma_elec_probs = zero_excluded_utilities_and_renormalize(
+            puma_elec_probs,
+            excluded_utilities=excluded_electric_utilities,
+            pumas=pumas,
+            puma_and_heating_fuel=puma_and_heating_fuel,
+            label="electric",
+        )
+
     if excluded_gas_utilities:
-        puma_gas_probs = zero_excluded_gas_utilities_and_renormalize(
+        puma_gas_probs = zero_excluded_utilities_and_renormalize(
             puma_gas_probs,
             excluded_utilities=excluded_gas_utilities,
             pumas=pumas,
             puma_and_heating_fuel=puma_and_heating_fuel,
+            label="gas",
         )
 
     elec_prior_weighted, gas_prior_weighted = calculate_prior_distributions(

--- a/tests/test_assign_utility_ny.py
+++ b/tests/test_assign_utility_ny.py
@@ -16,7 +16,7 @@ from data.resstock.utility.utils import (
     calculate_utility_probabilities,
     puma_id_series_for_join,
     sample_utility_per_building,
-    zero_excluded_gas_utilities_and_renormalize,
+    zero_excluded_utilities_and_renormalize,
 )
 from utils.utility_codes import get_ny_open_data_to_std_name
 
@@ -418,7 +418,7 @@ def test_sample_utility_per_building_deterministic_with_varying_probs():
 
 
 # ---------------------------------------------------------------------------
-# EXCLUDED_GAS_UTILITIES and zero_excluded_gas_utilities_and_renormalize
+# EXCLUDED_GAS_UTILITIES and zero_excluded_utilities_and_renormalize
 # ---------------------------------------------------------------------------
 
 
@@ -543,8 +543,8 @@ def test_zero_excluded_gas_utilities_no_excluded_cols_unchanged():
             "nyseg": [0.5, 1.0],
         }
     )
-    out = zero_excluded_gas_utilities_and_renormalize(
-        puma_gas_probs, excluded_utilities=EXCLUDED_GAS_UTILITIES
+    out = zero_excluded_utilities_and_renormalize(
+        puma_gas_probs, excluded_utilities=EXCLUDED_GAS_UTILITIES, label="gas"
     )
     df = cast(pl.DataFrame, out.collect())
     assert df.shape == (2, 3)
@@ -562,8 +562,8 @@ def test_zero_excluded_gas_utilities_renormalize():
             "nimo": [0.2, 0.3],
         }
     )
-    out = zero_excluded_gas_utilities_and_renormalize(
-        puma_gas_probs, excluded_utilities=EXCLUDED_GAS_UTILITIES
+    out = zero_excluded_utilities_and_renormalize(
+        puma_gas_probs, excluded_utilities=EXCLUDED_GAS_UTILITIES, label="gas"
     )
     df = cast(pl.DataFrame, out.collect())
     # 00100: stlaw zeroed, nyseg+nimo renormalized from 0.4+0.2 to sum 1
@@ -586,8 +586,11 @@ def test_zero_excluded_gas_utilities_bad_puma_raises_without_pumas():
         }
     )
     with pytest.raises(ValueError) as exc_info:
-        zero_excluded_gas_utilities_and_renormalize(
-            puma_gas_probs, excluded_utilities=EXCLUDED_GAS_UTILITIES, pumas=None
+        zero_excluded_utilities_and_renormalize(
+            puma_gas_probs,
+            excluded_utilities=EXCLUDED_GAS_UTILITIES,
+            pumas=None,
+            label="gas",
         )
     assert "00100" in str(exc_info.value)
     assert "excluded gas utilities" in str(exc_info.value).lower()
@@ -610,11 +613,12 @@ def test_zero_excluded_gas_utilities_bad_puma_uses_donor_with_pumas():
             "geometry": [box(0, 0, 1, 1), box(1, 0, 2, 1)],
         }
     )
-    out = zero_excluded_gas_utilities_and_renormalize(
+    out = zero_excluded_utilities_and_renormalize(
         puma_gas_probs,
         excluded_utilities=EXCLUDED_GAS_UTILITIES,
         pumas=pumas,
         puma_and_heating_fuel=None,
+        label="gas",
     )
     df = cast(pl.DataFrame, out.collect())
     # 00100 should get donor 00200's row: stlaw=0, nyseg=1
@@ -625,3 +629,39 @@ def test_zero_excluded_gas_utilities_bad_puma_uses_donor_with_pumas():
     for row in df.iter_rows(named=True):
         utility_cols = [c for c in row if c != "puma_id"]
         assert abs(sum(row[c] for c in utility_cols) - 1.0) < 1e-9
+
+
+def test_zero_excluded_electric_utilities_renormalize():
+    """Electric exclusion zeros columns and renormalizes (same helper, label=electric)."""
+    puma_elec_probs = pl.LazyFrame(
+        {
+            "puma_id": ["00100", "00200"],
+            "berlin_muni": [0.3, 0.0],
+            "bge": [0.5, 0.6],
+            "pepco": [0.2, 0.4],
+        }
+    )
+    out = zero_excluded_utilities_and_renormalize(
+        puma_elec_probs,
+        excluded_utilities=frozenset({"berlin_muni", "hagerstown_muni"}),
+        label="electric",
+    )
+    df = cast(pl.DataFrame, out.collect())
+    row = df.filter(pl.col("puma_id") == "00100").to_dicts()[0]
+    assert row["berlin_muni"] == 0.0
+    assert abs(row["bge"] + row["pepco"] - 1.0) < 1e-9
+    assert abs(row["bge"] - 0.5 / 0.7) < 1e-9
+
+
+def test_md_excluded_electric_utilities_in_state_configs():
+    """MD excluded_electric_utilities lists the small municipals + somerset_rec."""
+    from data.resstock.utils import load_state_configs
+
+    kwargs = load_state_configs()["MD"]["utility_assignment"]["kwargs"]
+    assert set(kwargs["excluded_electric_utilities"]) == {
+        "berlin_muni",
+        "hagerstown_muni",
+        "easton_muni",
+        "somerset_rec",
+    }
+    assert kwargs["excluded_gas_utilities"] == ["easton_muni"]


### PR DESCRIPTION
Zeroes out small MD municipal (and Somerset REC) utilities from ResStock building assignment so CAIRO/rate-design runs only cover utilities we have tariffs and analysis scope for.

Closes #479

## What's in this PR

Replaced the gas-only `zero_excluded_gas_utilities_and_renormalize` with a single fuel-agnostic `zero_excluded_utilities_and_renormalize(..., label="gas"|"electric")`. Same zero → donor-PUMA → renormalize logic for both fuels; callers just pass `label`. Wired through MD/CT assignment, tests, and the utility-assignment context doc.

**MD exclusions** (`state_configs.yaml`):
- Gas: `easton_muni`
- Electric: `berlin_muni`, `hagerstown_muni`, `easton_muni`, `somerset_rec`

Utilities stay in `utility_codes.py`; only assignment priors are zeroed.
