### PR TITLE
Fix manifest logging to track `*_sb` releases and track manually updated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ data/resstock/utility/csv/
 data/resstock/utility/parquet/
 data/resstock/utility/shapefiles/
 data/resstock/utility/zips/
+data/resstock/integrity_report_*.yaml
 data/pjm/_local_lmp/
 data/eia/hourly_loads/zone_parquet/
 data/eia/hourly_loads/utility_parquet/

--- a/data/resstock/Justfile
+++ b/data/resstock/Justfile
@@ -102,6 +102,22 @@ status *args:
 mark-crashed *args:
     cd "{{ path_local_repo }}" && uv run python -m data.resstock.manifest --mark-crashed {{ args }}
 
+# Deep integrity check: compare every file's modification time on EBS and S3
+# against what the manifest recorded as the pipeline's completion time.
+# Outputs a YAML report listing all files modified after the pipeline finished.
+#
+# EBS listing is fast (local stat calls).  S3 listing uses aws s3 ls --recursive
+# and can take several minutes for large releases — use --check-location ebs
+# to skip S3 when you only need to check local files.
+#
+# Examples:
+#   just -f data/resstock/Justfile check-integrity MD
+#   just -f data/resstock/Justfile check-integrity MD --check-location ebs
+#   just -f data/resstock/Justfile check-integrity MD --tolerance 600
+# just -f data/resstock/Justfile check-integrity NY --output /tmp/report.yaml
+check-integrity state *args:
+    cd "{{ path_local_repo }}" && uv run python -m data.resstock.manifest --check-integrity --state {{ state }} {{ args }}
+
 ################################################################################
 # Individual step recipes (for debugging and partial re-runs)
 #

--- a/data/resstock/main.py
+++ b/data/resstock/main.py
@@ -67,7 +67,6 @@ from data.resstock.manifest import (
     new_run_record,
     record_step,
     upsert_run,
-    write_manifest,
 )
 from data.resstock.metadata.add_vulnerability_columns import (
     add_vulnerability_columns,
@@ -480,9 +479,9 @@ def _assign_utility(
             check=False,
         ).returncode
         if upload_rc != 0:
-            print(
-                f"    WARNING: aws s3 cp exited with code {upload_rc} for {loc}.",
-                flush=True,
+            raise RuntimeError(
+                f"aws s3 cp failed (exit {upload_rc}): "
+                f"utility_assignment for {loc} → {s3_dest}"
             )
 
         print(f"    Done: utility assignment complete for {loc}.", flush=True)
@@ -584,10 +583,9 @@ def _add_monthly_loads(
                 check=False,
             ).returncode
             if upload_rc != 0:
-                print(
-                    f"  WARNING: aws s3 sync exited with code {upload_rc} "
-                    f"for load_curve_monthly/state={s}/.",
-                    flush=True,
+                raise RuntimeError(
+                    f"aws s3 sync failed (exit {upload_rc}): "
+                    f"load_curve_monthly/state={s}/ → {s3_dest}"
                 )
             else:
                 print("    Done.", flush=True)
@@ -905,6 +903,10 @@ def main(argv: list[str] | None = None) -> None:
     sb_file_types = [ft for ft in args.file_types if ft not in SB_EXCLUDED_FILE_TYPES]
 
     # ── Manifest: start a run record ──────────────────────────────────────────
+    # Ensure _sb directory and manifest exist before any I/O so that even a
+    # pre-flight crash produces a record in the _sb manifest.
+    path_sb.mkdir(parents=True, exist_ok=True)
+
     run = new_run_record(
         release=release,
         release_sb=release_sb,
@@ -935,6 +937,10 @@ def main(argv: list[str] | None = None) -> None:
         # These run before any I/O so the pipeline halts immediately on conflicts
         # that would otherwise corrupt the _sb release mid-run.
         print("Running pre-flight validations...", flush=True)
+
+        # Record the run in _sb immediately so that even a pre-flight crash
+        # leaves a trace in the manifest.
+        upsert_run(path_sb, run)
 
         # Retroactively mark any stale in_progress runs left by a previous
         # ungraceful exit (e.g. OOM kill, SIGKILL) as crashed.
@@ -1004,7 +1010,6 @@ def main(argv: list[str] | None = None) -> None:
             file_types=sb_file_types,
         )
         path_sb.mkdir(parents=True, exist_ok=True)
-        write_manifest(path_sb, {"runs": []})
         print("Validating clone...", flush=True)
         validate_local_files(
             label="clone (step 1b)",
@@ -1095,17 +1100,29 @@ def main(argv: list[str] | None = None) -> None:
         # ── 2b. Assign electric/gas utilities ─────────────────────────────────
         if args.assign_utility and "metadata" in args.file_types:
             print("Assigning utilities...", flush=True)
-            _assign_utility(
-                states=args.state,
-                path_sb=path_sb,
-                sample=args.sample,
-                s3_base_sb=s3_base_sb,
-                path_s3_gis_dir=args.path_s3_gis_dir,
-                electric_poly_filename=args.electric_poly_filename,
-                gas_poly_filename=args.gas_poly_filename,
-            )
-            record_step(run, "assign_utility")
-            upsert_run(path_sb, run)
+            try:
+                _assign_utility(
+                    states=args.state,
+                    path_sb=path_sb,
+                    sample=args.sample,
+                    s3_base_sb=s3_base_sb,
+                    path_s3_gis_dir=args.path_s3_gis_dir,
+                    electric_poly_filename=args.electric_poly_filename,
+                    gas_poly_filename=args.gas_poly_filename,
+                )
+                record_step(run, "assign_utility")
+                upsert_run(path_sb, run)
+                upload_manifest(path_sb, s3_base_sb)
+            except Exception as exc:
+                run.setdefault("warnings", []).append(
+                    f"assign_utility S3 upload failed: {exc}"
+                )
+                upsert_run(path_sb, run)
+                try:
+                    upload_manifest(path_sb, s3_base_sb)
+                except Exception:
+                    pass
+                raise
             gc.collect()
 
         # ── 2c. Modify load curves ─────────────────────────────────────────────
@@ -1147,43 +1164,73 @@ def main(argv: list[str] | None = None) -> None:
         # ── 2d. Add monthly load curves ────────────────────────────────────────
         if args.add_monthly_loads and "load_curve_hourly" in args.file_types:
             print("Adding monthly load curves...", flush=True)
-            processed_monthly = _add_monthly_loads(
-                states=args.state,
-                path_sb=path_sb,
-                upgrade_ids=args.upgrade_ids,
-                release=release,
-                s3_base_sb=s3_base_sb,
-                sample=args.sample,
-                workers=args.monthly_workers,
-            )
-            record_step(run, "add_monthly_loads", processed=processed_monthly)
-            upsert_run(path_sb, run)
+            try:
+                processed_monthly = _add_monthly_loads(
+                    states=args.state,
+                    path_sb=path_sb,
+                    upgrade_ids=args.upgrade_ids,
+                    release=release,
+                    s3_base_sb=s3_base_sb,
+                    sample=args.sample,
+                    workers=args.monthly_workers,
+                )
+                record_step(run, "add_monthly_loads", processed=processed_monthly)
+                upsert_run(path_sb, run)
+                upload_manifest(path_sb, s3_base_sb)
+            except Exception as exc:
+                run.setdefault("warnings", []).append(
+                    f"add_monthly_loads S3 upload failed: {exc}"
+                )
+                upsert_run(path_sb, run)
+                try:
+                    upload_manifest(path_sb, s3_base_sb)
+                except Exception:
+                    pass
+                raise
             gc.collect()
 
         # ── 3. Upload ─────────────────────────────────────────────────────────
         print("Uploading raw ResStock data to S3...", flush=True)
-        upload(
-            state=args.state,
-            file_types=args.file_types,
-            release=release,
-            path_output_dir=args.path_output_dir,
-            path_s3_dir=args.path_s3_dir,
-        )
-        record_step(run, "upload_raw", s3_base=s3_base_raw)
-        upsert_run(path_raw, run)
-        upload_manifest(path_raw, s3_base_raw)
+        try:
+            upload(
+                state=args.state,
+                file_types=args.file_types,
+                release=release,
+                path_output_dir=args.path_output_dir,
+                path_s3_dir=args.path_s3_dir,
+            )
+            record_step(run, "upload_raw", s3_base=s3_base_raw)
+            upsert_run(path_raw, run)
+            upload_manifest(path_raw, s3_base_raw)
+        except Exception as exc:
+            run.setdefault("warnings", []).append(f"upload_raw S3 upload failed: {exc}")
+            upsert_run(path_raw, run)
+            try:
+                upload_manifest(path_raw, s3_base_raw)
+            except Exception:
+                pass
+            raise
 
         print("Uploading modified sb ResStock data to S3...", flush=True)
-        upload(
-            state=args.state,
-            file_types=sb_file_types,
-            release=release_sb,
-            path_output_dir=args.path_output_dir,
-            path_s3_dir=args.path_s3_dir,
-        )
-        record_step(run, "upload_sb", s3_base=s3_base_sb)
-        upsert_run(path_sb, run)
-        upload_manifest(path_sb, s3_base_sb)
+        try:
+            upload(
+                state=args.state,
+                file_types=sb_file_types,
+                release=release_sb,
+                path_output_dir=args.path_output_dir,
+                path_s3_dir=args.path_s3_dir,
+            )
+            record_step(run, "upload_sb", s3_base=s3_base_sb)
+            upsert_run(path_sb, run)
+            upload_manifest(path_sb, s3_base_sb)
+        except Exception as exc:
+            run.setdefault("warnings", []).append(f"upload_sb S3 upload failed: {exc}")
+            upsert_run(path_sb, run)
+            try:
+                upload_manifest(path_sb, s3_base_sb)
+            except Exception:
+                pass
+            raise
 
         print("Validating S3 uploads...", flush=True)
         validate_s3_objects(
@@ -1204,9 +1251,13 @@ def main(argv: list[str] | None = None) -> None:
         )
 
         # ── Done ──────────────────────────────────────────────────────────────
+        # Finalize the run record before uploading manifests to S3 so the S3
+        # copy reflects the completed status, not in_progress.
         finish_run(run)
         upsert_run(path_raw, run)
         upsert_run(path_sb, run)
+        upload_manifest(path_raw, s3_base_raw)
+        upload_manifest(path_sb, s3_base_sb)
         print("Pipeline complete.", flush=True)
 
     except Exception as e:

--- a/data/resstock/main.py
+++ b/data/resstock/main.py
@@ -938,14 +938,16 @@ def main(argv: list[str] | None = None) -> None:
         # that would otherwise corrupt the _sb release mid-run.
         print("Running pre-flight validations...", flush=True)
 
+        # Retroactively mark any stale in_progress runs left by a previous
+        # ungraceful exit (e.g. OOM kill, SIGKILL) as crashed.  Must run
+        # *before* inserting this run — otherwise mark_crashed_runs would
+        # immediately mark the brand-new in_progress entry as crashed.
+        mark_crashed_runs(path_raw)
+        mark_crashed_runs(path_sb)
+
         # Record the run in _sb immediately so that even a pre-flight crash
         # leaves a trace in the manifest.
         upsert_run(path_sb, run)
-
-        # Retroactively mark any stale in_progress runs left by a previous
-        # ungraceful exit (e.g. OOM kill, SIGKILL) as crashed.
-        mark_crashed_runs(path_raw)
-        mark_crashed_runs(path_sb)
         run_warnings = collect_run_warnings(
             file_types=args.file_types,
             upgrade_ids=args.upgrade_ids,

--- a/data/resstock/manifest.py
+++ b/data/resstock/manifest.py
@@ -458,9 +458,20 @@ def print_status(
             )
 
         if check_ebs and check_s3:
-            ebs_runs = ebs_manifest.get("runs", [])
-            s3_runs = s3_manifest.get("runs", [])
-            if ebs_runs and s3_runs:
+            ebs_runs = _filter_runs(
+                ebs_manifest.get("runs", []), states=states, upgrades=upgrades
+            )
+            s3_runs = _filter_runs(
+                s3_manifest.get("runs", []), states=states, upgrades=upgrades
+            )
+            if not ebs_runs or not s3_runs:
+                filter_desc = _describe_filter(states, upgrades)
+                print(
+                    f"  EBS ↔ S3:   ? cannot determine sync "
+                    f"(no matching runs on {'EBS' if not ebs_runs else 'S3'}"
+                    f" for filter: {filter_desc})"
+                )
+            else:
                 ebs_last = ebs_runs[-1].get("run_id")
                 s3_last = s3_runs[-1].get("run_id")
                 if ebs_last == s3_last:

--- a/data/resstock/manifest.py
+++ b/data/resstock/manifest.py
@@ -41,7 +41,7 @@ import subprocess
 import sys
 import tempfile
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -487,6 +487,434 @@ def print_status(
         print()
 
 
+# ── Integrity check ───────────────────────────────────────────────────────────
+
+# Maps pipeline step names to the file-type directories they create or modify.
+# Used to derive (1) which file types the manifest expects and (2) the
+# most recent ``completed_at`` timestamp for each file type.
+_STEP_FILE_TYPES: dict[str, frozenset[str]] = {
+    "fetch": frozenset(),  # filled from args.file_types at runtime (raw only)
+    "clone": frozenset(),  # filled from args.file_types minus SB_EXCLUDED (_sb only)
+    "modify_metadata": frozenset({"metadata"}),
+    "assign_utility": frozenset({"metadata_utility"}),
+    "approximate_non_hp_load": frozenset({"load_curve_hourly"}),
+    "adjust_mf_electricity": frozenset({"load_curve_hourly"}),
+    "add_monthly_loads": frozenset({"load_curve_monthly"}),
+    "upload_raw": frozenset(),  # does not create new types
+    "upload_sb": frozenset(),
+}
+
+
+def _parse_s3_ls_line(line: str) -> tuple[str, int, datetime] | None:
+    """Parse one line of ``aws s3 ls --recursive`` output.
+
+    Each line looks like:  2026-07-17 17:25:27    12345 path/to/file.parquet
+    Returns (key, size_bytes, last_modified) or None on parse failure.
+    """
+    parts = line.split(maxsplit=3)
+    if len(parts) < 4:
+        return None
+    try:
+        ts = datetime.fromisoformat(f"{parts[0]}T{parts[1]}+00:00")
+        size = int(parts[2])
+        key = parts[3]
+        return (key, size, ts)
+    except (ValueError, IndexError):
+        return None
+
+
+def _list_s3_files(s3_prefix: str) -> list[tuple[str, int, datetime]]:
+    """Recursively list all objects under an S3 prefix.
+
+    Returns a list of (relative_key, size_bytes, last_modified_utc).
+    The relative_key is stripped of the prefix so it matches local paths.
+    """
+    result = subprocess.run(
+        ["aws", "s3", "ls", "--recursive", s3_prefix],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+
+    prefix_path = s3_prefix.split("/", 3)[-1] if s3_prefix.count("/") >= 3 else ""
+
+    entries: list[tuple[str, int, datetime]] = []
+    for line in result.stdout.splitlines():
+        parsed = _parse_s3_ls_line(line)
+        if parsed:
+            key, size, ts = parsed
+            rel_key = key.removeprefix(prefix_path).lstrip("/")
+            entries.append((rel_key, size, ts))
+    return entries
+
+
+def _list_ebs_files(local_dir: Path, state: str) -> list[tuple[str, int, datetime]]:
+    """List all files under a local release directory filtered by state partition.
+
+    Returns (relative_path, size_bytes, mtime_utc).
+    """
+    entries: list[tuple[str, int, datetime]] = []
+    if not local_dir.is_dir():
+        return entries
+    for f in local_dir.rglob("*"):
+        if not f.is_file():
+            continue
+        rel = str(f.relative_to(local_dir))
+        if f"state={state}" not in rel:
+            continue
+        if rel == MANIFEST_FILENAME or rel.startswith(f"{MANIFEST_FILENAME}/"):
+            continue
+        stat = f.stat()
+        mtime = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
+        entries.append((rel, stat.st_size, mtime))
+    return entries
+
+
+def _file_types_from_paths(paths: list[str]) -> set[str]:
+    """Extract top-level file-type directory names from relative paths."""
+    types: set[str] = set()
+    for p in paths:
+        top = p.split("/", 1)[0]
+        if top and top != MANIFEST_FILENAME:
+            types.add(top)
+    return types
+
+
+def _expected_file_types(runs: list[dict[str, Any]], *, is_sb: bool) -> set[str]:
+    """Derive expected file-type directories from *all* matching manifest runs.
+
+    Pipeline runs are additive: a later run that only fetches load curves does
+    not erase metadata written by an earlier run.  So the expected set is the
+    **union** across every run that touched this state, not just the latest.
+
+    For the raw release: union of ``args.file_types`` over all runs.
+    For the _sb release: the same union minus ``SB_EXCLUDED_FILE_TYPES``, plus
+    any types produced by completed steps (``metadata_utility``,
+    ``load_curve_monthly``, etc.).
+    """
+    from data.resstock.constants import SB_EXCLUDED_FILE_TYPES
+
+    expected: set[str] = set()
+    for run in runs:
+        base_types = set(run.get("args", {}).get("file_types", []))
+        if is_sb:
+            expected |= {ft for ft in base_types if ft not in SB_EXCLUDED_FILE_TYPES}
+            for step in run.get("steps", []):
+                expected |= set(_STEP_FILE_TYPES.get(step.get("step", ""), frozenset()))
+        else:
+            expected |= base_types
+    return expected
+
+
+def _latest_step_times_by_file_type(
+    runs: list[dict[str, Any]], *, is_sb: bool
+) -> dict[str, datetime]:
+    """Map each file type to the newest step ``completed_at`` across all runs."""
+    from data.resstock.constants import SB_EXCLUDED_FILE_TYPES
+
+    times: dict[str, datetime] = {}
+
+    for run in runs:
+        args = run.get("args", {})
+        base_types = set(args.get("file_types", []))
+        if is_sb:
+            base_types = {ft for ft in base_types if ft not in SB_EXCLUDED_FILE_TYPES}
+
+        for step in run.get("steps", []):
+            name = step.get("step", "")
+            completed_raw = step.get("completed_at")
+            if not completed_raw:
+                continue
+            completed = datetime.fromisoformat(completed_raw).astimezone(timezone.utc)
+
+            if name == "fetch" and not is_sb:
+                touched = base_types
+            elif name == "clone" and is_sb:
+                touched = base_types
+            elif name == "upload_raw" and not is_sb:
+                touched = base_types
+            elif name == "upload_sb" and is_sb:
+                touched = set(base_types)
+                for s in run.get("steps", []):
+                    touched |= set(_STEP_FILE_TYPES.get(s.get("step", ""), frozenset()))
+            else:
+                touched = set(_STEP_FILE_TYPES.get(name, frozenset()))
+
+            for ft in touched:
+                if ft not in times or completed > times[ft]:
+                    times[ft] = completed
+
+    return times
+
+
+def _aggregate_mtimes_by_file_type(
+    files: list[tuple[str, int, datetime]],
+) -> dict[str, tuple[datetime, datetime, int]]:
+    """Group files by top-level file type.
+
+    Returns ``{file_type: (min_mtime, max_mtime, n_files)}``.
+    """
+    agg: dict[str, tuple[datetime, datetime, int]] = {}
+    for path, _size, mtime in files:
+        ft = path.split("/", 1)[0]
+        if ft == MANIFEST_FILENAME:
+            continue
+        if ft not in agg:
+            agg[ft] = (mtime, mtime, 1)
+        else:
+            mn, mx, n = agg[ft]
+            agg[ft] = (min(mn, mtime), max(mx, mtime), n + 1)
+    return agg
+
+
+def check_integrity(
+    *,
+    release: str,
+    state: str,
+    ebs_base: str,
+    s3_base: str,
+    tolerance_seconds: int = 300,
+    output_path: Path | None = None,
+    location: str = "both",
+) -> dict[str, Any]:
+    """Check that file-type directories match the manifest (bijection + timestamps).
+
+    For each of the raw and ``_sb`` releases, scoped to *state*:
+
+    1. **Expected file types** are the **union** across *all* matching
+       manifest runs (not just the latest).  Pipeline runs are additive: a
+       later run that only fetches load curves does not erase metadata from
+       an earlier run.  For ``_sb``, ``SB_EXCLUDED_FILE_TYPES`` are dropped
+       and step-produced types (``metadata_utility``, ``load_curve_monthly``)
+       are included.
+    2. **Actual file types** are the top-level directories under the release that
+       contain ``state=<state>`` data, on EBS and/or S3.
+    3. Fail if a type exists on disk/S3 but is not expected by the manifest,
+       or if the manifest expects a type that is missing.
+    4. For each matching type, compare the newest file mtime against the
+       newest manifest step (across all runs) that touched that type.  Fail
+       if the newest file is more than ``tolerance_seconds`` after that step.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    from tqdm import tqdm
+
+    release_sb = f"{release}_sb"
+    releases_to_check = [release, release_sb]
+
+    check_ebs = location in ("ebs", "both")
+    check_s3 = location in ("s3", "both")
+
+    report: dict[str, Any] = {
+        "state": state,
+        "checked_at": _now_iso(),
+        "tolerance_seconds": tolerance_seconds,
+        "location": location,
+        "releases_checked": releases_to_check,
+        "mismatches": [],
+        "summary": "",
+    }
+
+    all_mismatches: list[dict[str, Any]] = []
+
+    for rel in releases_to_check:
+        is_sb = rel.endswith("_sb")
+        ebs_dir = Path(ebs_base) / rel
+        s3_prefix = f"{s3_base.rstrip('/')}/{rel}/"
+
+        # Prefer the local manifest; fall back to S3 if EBS has none.
+        manifest = read_manifest(ebs_dir)
+        if not manifest.get("runs") and check_s3:
+            manifest = read_manifest_from_s3(f"{s3_prefix}{MANIFEST_FILENAME}")
+
+        runs = _filter_runs(manifest.get("runs", []), states=[state])
+        if not runs:
+            all_mismatches.append(
+                {
+                    "release": rel,
+                    "location": "manifest",
+                    "issue": f"No pipeline run found for state={state}",
+                    "file_type": None,
+                }
+            )
+            continue
+
+        expected = _expected_file_types(runs, is_sb=is_sb)
+        step_times = _latest_step_times_by_file_type(runs, is_sb=is_sb)
+        run_ids = [r.get("run_id", "?") for r in runs]
+
+        print(
+            f"  [{rel}] Expected file types from {len(runs)} manifest run(s): "
+            f"{sorted(expected) or '(none)'}",
+            flush=True,
+        )
+
+        # List files for this state
+        loc_labels = [x for x, on in (("EBS", check_ebs), ("S3", check_s3)) if on]
+        print(
+            f"  [{rel}] Listing state={state} files ({' + '.join(loc_labels)})...",
+            flush=True,
+        )
+
+        ebs_files: list[tuple[str, int, datetime]] = []
+        s3_files: list[tuple[str, int, datetime]] = []
+
+        if check_ebs and check_s3:
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                fut_ebs = pool.submit(_list_ebs_files, ebs_dir, state)
+                fut_s3 = pool.submit(_list_s3_files, s3_prefix)
+                ebs_files = fut_ebs.result()
+                s3_files = [
+                    (k, sz, ts)
+                    for k, sz, ts in fut_s3.result()
+                    if f"state={state}" in k and not k.endswith(MANIFEST_FILENAME)
+                ]
+        elif check_ebs:
+            ebs_files = _list_ebs_files(ebs_dir, state)
+        else:
+            s3_files = [
+                (k, sz, ts)
+                for k, sz, ts in _list_s3_files(s3_prefix)
+                if f"state={state}" in k and not k.endswith(MANIFEST_FILENAME)
+            ]
+
+        checks: list[tuple[str, list[tuple[str, int, datetime]]]] = []
+        if check_ebs:
+            checks.append(("ebs", ebs_files))
+        if check_s3:
+            checks.append(("s3", s3_files))
+
+        for loc_name, files in checks:
+            actual_types = _file_types_from_paths([p for p, _, _ in files])
+            print(
+                f"  [{rel}/{loc_name}] Actual file types: "
+                f"{sorted(actual_types) or '(none)'} "
+                f"({len(files):,} files)",
+                flush=True,
+            )
+
+            unexpected = sorted(actual_types - expected)
+            missing = sorted(expected - actual_types)
+
+            for ft in unexpected:
+                all_mismatches.append(
+                    {
+                        "release": rel,
+                        "location": loc_name,
+                        "issue": "unexpected_file_type",
+                        "file_type": ft,
+                        "detail": (
+                            f"Directory '{ft}/' exists for state={state} but is not "
+                            f"expected from the union of {len(runs)} manifest run(s) "
+                            f"(run_ids={run_ids})."
+                        ),
+                    }
+                )
+
+            for ft in missing:
+                all_mismatches.append(
+                    {
+                        "release": rel,
+                        "location": loc_name,
+                        "issue": "missing_file_type",
+                        "file_type": ft,
+                        "detail": (
+                            f"Manifest expects '{ft}/' for state={state} "
+                            f"(union of run_ids={run_ids}) but it was not found."
+                        ),
+                    }
+                )
+
+            # Timestamp check for types present in both expected and actual
+            mtimes = _aggregate_mtimes_by_file_type(files)
+            shared = sorted(expected & actual_types)
+            with tqdm(
+                total=len(shared),
+                desc=f"  {rel}/{loc_name} timestamps",
+                unit="type",
+                leave=True,
+            ) as pbar:
+                for ft in shared:
+                    pbar.update(1)
+                    _mn, mx, n_files = mtimes[ft]
+                    step_ts = step_times.get(ft)
+                    if step_ts is None:
+                        # No step timestamp for this type — skip time check
+                        continue
+                    cutoff = step_ts + timedelta(seconds=tolerance_seconds)
+                    if mx > cutoff:
+                        all_mismatches.append(
+                            {
+                                "release": rel,
+                                "location": loc_name,
+                                "issue": "timestamp_mismatch",
+                                "file_type": ft,
+                                "detail": (
+                                    f"Newest file in '{ft}/' "
+                                    f"({mx.isoformat(timespec='seconds')}) is "
+                                    f"{int((mx - step_ts).total_seconds())}s after "
+                                    f"the latest manifest step for this type "
+                                    f"({step_ts.isoformat(timespec='seconds')}); "
+                                    f"tolerance={tolerance_seconds}s. "
+                                    f"({n_files:,} files checked)"
+                                ),
+                                "file_mtime_max": mx.isoformat(timespec="seconds"),
+                                "step_completed_at": step_ts.isoformat(
+                                    timespec="seconds"
+                                ),
+                                "delta_seconds": int((mx - step_ts).total_seconds()),
+                                "n_files": n_files,
+                            }
+                        )
+
+    report["mismatches"] = all_mismatches
+
+    n = len(all_mismatches)
+    if n == 0:
+        report["summary"] = (
+            f"All file types for state={state} match the manifest on "
+            f"{location} (set equality + timestamps within {tolerance_seconds}s)."
+        )
+    else:
+        by_issue: dict[str, int] = {}
+        for m in all_mismatches:
+            by_issue[m["issue"]] = by_issue.get(m["issue"], 0) + 1
+        parts = [f"{count} {issue}" for issue, count in sorted(by_issue.items())]
+        report["summary"] = f"Found {n} integrity issue(s): " + ", ".join(parts) + "."
+
+    if output_path is None:
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        output_path = Path(__file__).parent / f"integrity_report_{state}_{ts}.yaml"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w") as f:
+        yaml.dump(report, f, default_flow_style=False, sort_keys=False)
+
+    print(f"\n{'=' * 72}")
+    print(f"Integrity check: state={state}")
+    print(f"{'=' * 72}")
+    print(f"  Releases:  {', '.join(releases_to_check)}")
+    print(f"  Location:  {location}")
+    print(f"  Tolerance: {tolerance_seconds}s")
+    print(f"  Result:    {report['summary']}")
+    if all_mismatches:
+        print("\n  Issues:")
+        for m in all_mismatches[:30]:
+            print(
+                f"    [{m['location'].upper()}] {m['release']}/"
+                f"{m.get('file_type') or '?'} — {m['issue']}"
+            )
+            if m.get("detail"):
+                print(f"      {m['detail']}")
+        if n > 30:
+            print(f"    ... and {n - 30} more (see full report)")
+    print(f"\n  Full report: {output_path}")
+    print(f"{'=' * 72}\n")
+
+    return report
+
+
 def _status_main() -> None:
     """CLI entry point for ``uv run python -m data.resstock.manifest``."""
     with CONFIG_PATH.open() as f:
@@ -596,6 +1024,47 @@ def _status_main() -> None:
         ),
     )
 
+    integrity_group = parser.add_argument_group(
+        "integrity check",
+        "Deep per-file comparison of actual modification times against the manifest. "
+        "Checks both EBS and S3, for both raw and _sb releases.",
+    )
+    integrity_group.add_argument(
+        "--check-integrity",
+        action="store_true",
+        help=(
+            "Run a full integrity check for the given state(s). "
+            "Requires --state.  Compares every file's modification time against "
+            "the pipeline's completed_at timestamp.  Outputs a YAML report."
+        ),
+    )
+    integrity_group.add_argument(
+        "--tolerance",
+        type=int,
+        default=300,
+        metavar="SECS",
+        help=(
+            "Seconds after pipeline completion within which a file's mtime is "
+            "still considered in sync. Default 300 (5 minutes)."
+        ),
+    )
+    integrity_group.add_argument(
+        "--check-location",
+        choices=["ebs", "s3", "both"],
+        default="both",
+        help=(
+            "Which storage to check. 'ebs' is fast (local stat calls only). "
+            "'s3' requires aws s3 ls --recursive and can take minutes for large releases. "
+            "Default: both."
+        ),
+    )
+    integrity_group.add_argument(
+        "--output",
+        default=None,
+        metavar="PATH",
+        help="Path to write the integrity report YAML. Default: auto-generated in data/resstock/.",
+    )
+
     args = parser.parse_args()
 
     # Strip trailing _sb so the user can pass either form and get both variants.
@@ -609,6 +1078,22 @@ def _status_main() -> None:
             n = mark_crashed_runs(d, exit_code=args.exit_code)
             if n == 0:
                 print(f"  {d}: no stale in_progress runs found.")
+        return
+
+    if args.check_integrity:
+        if not args.state:
+            parser.error("--check-integrity requires --state")
+        output_path = Path(args.output) if args.output else None
+        for s in args.state:
+            check_integrity(
+                release=release,
+                state=s,
+                ebs_base=ebs_base,
+                s3_base=cfg["paths"]["s3_dir"],
+                tolerance_seconds=args.tolerance,
+                location=args.check_location,
+                output_path=output_path,
+            )
         return
 
     print_status(

--- a/data/resstock/utils.py
+++ b/data/resstock/utils.py
@@ -57,12 +57,18 @@ def upload(
     path_output_dir: str | Path,
     path_s3_dir: str,
 ) -> None:
-    """Sync fetched/modified local files to S3 (data only, not the manifest)."""
+    """Sync fetched/modified local files to S3 (data only, not the manifest).
+
+    Raises RuntimeError if any ``aws s3 sync`` command fails, listing every
+    failed combination.  All combinations are attempted regardless so a partial
+    failure does not silently skip remaining uploads.
+    """
     local_base = Path(path_output_dir) / release
     s3_base = f"{path_s3_dir.rstrip('/')}/{release}"
 
     total_combos = len(file_types) * len(state)
     combo_idx = 0
+    failures: list[str] = []
     for file_type in file_types:
         for s in state:
             combo_idx += 1
@@ -83,12 +89,20 @@ def upload(
                 check=False,
             )
             if result.returncode != 0:
-                print(
-                    f"    WARNING: aws s3 sync exited with code {result.returncode}",
-                    flush=True,
+                msg = (
+                    f"aws s3 sync failed (exit {result.returncode}): "
+                    f"{file_type}/state={s} → {s3_path}"
                 )
+                print(f"    ERROR: {msg}", flush=True)
+                failures.append(msg)
             else:
                 print("    Done.", flush=True)
+
+    if failures:
+        raise RuntimeError(
+            f"upload() failed for {len(failures)} combination(s):\n"
+            + "\n".join(f"  - {f}" for f in failures)
+        )
 
 
 def upload_manifest(local_dir: Path, s3_base: str) -> None:

--- a/tests/test_resstock_manifest.py
+++ b/tests/test_resstock_manifest.py
@@ -1,0 +1,278 @@
+"""Tests for data/resstock/manifest.py provenance and sync behavior.
+
+Covers the four fixes applied to the manifest system:
+
+Fix 1 (upsert_run preserves history) — verified via upsert_run directly; the
+       destructive write_manifest(path_sb, {"runs": []}) call was removed from
+       main.py, so sequential runs now accumulate records rather than resetting.
+Fix 2 (manifests uploaded after finish_run) — not tested here because upload
+       requires real S3 credentials.  The ordering is verified by inspection.
+Fix 3 (EBS↔S3 sync check respects --state/--upgrade filter) — tested via
+       print_status with monkeypatched S3 reads.
+Fix 4 (early crash leaves _sb trace) — tested by verifying upsert_run creates
+       the manifest file if none exists yet (the _sb dir is now created before
+       the try block in main.py).
+"""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from data.resstock.manifest import (
+    _filter_runs,
+    finish_run,
+    new_run_record,
+    print_status,
+    read_manifest,
+    record_step,
+    upsert_run,
+)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_run(run_id: str, states: list[str], upgrade_ids: list[str]) -> dict[str, Any]:
+    run = new_run_record(
+        release="res_2024_amy2018_2",
+        release_sb="res_2024_amy2018_2_sb",
+        states=states,
+        upgrade_ids=upgrade_ids,
+        file_types=["metadata"],
+        flags={},
+    )
+    run["run_id"] = run_id
+    return run
+
+
+def _capture_status(**kwargs: Any) -> str:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        print_status(**kwargs)
+    return buf.getvalue()
+
+
+# ── Fix 1: sequential state runs preserve _sb history ────────────────────────
+
+
+def test_sequential_states_accumulate_in_sb_manifest(tmp_path: Path) -> None:
+    """Running MD then NY must leave both records in the _sb manifest."""
+    sb_dir = tmp_path / "res_2024_amy2018_2_sb"
+
+    md_run = _make_run("run-MD-001", ["MD"], ["0", "2"])
+    upsert_run(sb_dir, md_run)
+
+    ny_run = _make_run("run-NY-002", ["NY"], ["0", "2"])
+    upsert_run(sb_dir, ny_run)
+
+    manifest = read_manifest(sb_dir)
+    ids = [r["run_id"] for r in manifest.get("runs", [])]
+    assert "run-MD-001" in ids, "MD run was erased after NY run"
+    assert "run-NY-002" in ids, "NY run not recorded"
+    assert len(ids) == 2
+
+
+def test_upsert_updates_existing_run_in_place(tmp_path: Path) -> None:
+    """Calling upsert_run twice with the same run_id must update, not duplicate."""
+    release_dir = tmp_path / "release"
+
+    run = _make_run("run-001", ["MD"], ["0"])
+    upsert_run(release_dir, run)
+    record_step(run, "fetch")
+    upsert_run(release_dir, run)
+
+    manifest = read_manifest(release_dir)
+    ids = [r["run_id"] for r in manifest.get("runs", [])]
+    assert ids.count("run-001") == 1, "Duplicate run_id inserted"
+    steps = manifest["runs"][0]["steps"]
+    assert any(s["step"] == "fetch" for s in steps), "Step not updated"
+
+
+def test_upsert_creates_manifest_when_missing(tmp_path: Path) -> None:
+    """upsert_run must create manifest.yaml if the directory has none (Fix 4)."""
+    release_dir = tmp_path / "new_release"
+    release_dir.mkdir()
+    assert not (release_dir / "manifest.yaml").exists()
+
+    run = _make_run("run-001", ["MD"], ["0"])
+    upsert_run(release_dir, run)
+
+    assert (release_dir / "manifest.yaml").exists()
+    manifest = read_manifest(release_dir)
+    assert manifest["runs"][0]["run_id"] == "run-001"
+
+
+# ── Fix 2: finish_run marks status completed ─────────────────────────────────
+
+
+def test_finish_run_marks_completed(tmp_path: Path) -> None:
+    """finish_run + upsert_run must write status=completed to the manifest."""
+    release_dir = tmp_path / "release"
+    run = _make_run("run-001", ["MD"], ["0"])
+    upsert_run(release_dir, run)
+
+    finish_run(run)
+    upsert_run(release_dir, run)
+
+    manifest = read_manifest(release_dir)
+    stored = manifest["runs"][0]
+    assert stored["status"] == "completed"
+    assert "completed_at" in stored
+
+
+# ── Fix 3: EBS↔S3 sync respects --state filter ───────────────────────────────
+
+
+def _fake_s3_manifest(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"runs": runs}
+
+
+def test_sync_check_reports_in_sync_for_matching_state(tmp_path: Path) -> None:
+    """Both EBS and S3 have the same MD run → in sync."""
+    ebs_base = str(tmp_path)
+    sb_dir = tmp_path / "res_2024_amy2018_2_sb"
+
+    md_run = _make_run("run-MD-001", ["MD"], ["0", "2"])
+    finish_run(md_run)
+    upsert_run(sb_dir, md_run)
+
+    with patch(
+        "data.resstock.manifest.read_manifest_from_s3",
+        return_value=_fake_s3_manifest([md_run]),
+    ):
+        output = _capture_status(
+            release="res_2024_amy2018_2",
+            release_sb="res_2024_amy2018_2_sb",
+            ebs_base=ebs_base,
+            s3_base="s3://data.sb/nrel/resstock",
+            states=["MD"],
+            variant="sb",
+        )
+
+    assert "✓ in sync" in output, f"Expected in sync:\n{output}"
+
+
+def test_sync_check_detects_divergence_for_matching_state(tmp_path: Path) -> None:
+    """EBS has a newer MD run than S3 → out of sync."""
+    ebs_base = str(tmp_path)
+    sb_dir = tmp_path / "res_2024_amy2018_2_sb"
+
+    old_md_run = _make_run("run-MD-001", ["MD"], ["0", "2"])
+    finish_run(old_md_run)
+    new_md_run = _make_run("run-MD-002", ["MD"], ["0", "2"])
+    finish_run(new_md_run)
+    upsert_run(sb_dir, old_md_run)
+    upsert_run(sb_dir, new_md_run)
+
+    with patch(
+        "data.resstock.manifest.read_manifest_from_s3",
+        return_value=_fake_s3_manifest([old_md_run]),
+    ):
+        output = _capture_status(
+            release="res_2024_amy2018_2",
+            release_sb="res_2024_amy2018_2_sb",
+            ebs_base=ebs_base,
+            s3_base="s3://data.sb/nrel/resstock",
+            states=["MD"],
+            variant="sb",
+        )
+
+    assert "OUT OF SYNC" in output, f"Expected out of sync:\n{output}"
+
+
+def test_sync_check_does_not_use_unfiltered_run_ids(tmp_path: Path) -> None:
+    """NY run is newer than MD run; status --state MD must not report in sync
+    based on the NY run IDs when EBS and S3 hold different MD runs."""
+    ebs_base = str(tmp_path)
+    sb_dir = tmp_path / "res_2024_amy2018_2_sb"
+
+    # EBS: old MD run, then NY run
+    old_md_run = _make_run("run-MD-001", ["MD"], ["0", "2"])
+    finish_run(old_md_run)
+    ny_run = _make_run("run-NY-003", ["NY"], ["0", "2"])
+    finish_run(ny_run)
+    upsert_run(sb_dir, old_md_run)
+    upsert_run(sb_dir, ny_run)
+
+    # S3: completely different MD run, same NY run
+    new_md_run_s3 = _make_run("run-MD-002", ["MD"], ["0", "2"])
+    finish_run(new_md_run_s3)
+    s3_manifest = _fake_s3_manifest([new_md_run_s3, ny_run])
+
+    with patch(
+        "data.resstock.manifest.read_manifest_from_s3",
+        return_value=s3_manifest,
+    ):
+        output = _capture_status(
+            release="res_2024_amy2018_2",
+            release_sb="res_2024_amy2018_2_sb",
+            ebs_base=ebs_base,
+            s3_base="s3://data.sb/nrel/resstock",
+            states=["MD"],
+            variant="sb",
+        )
+
+    # NY run IDs match, but MD run IDs differ — should NOT claim in sync
+    assert "OUT OF SYNC" in output, (
+        f"Sync check incorrectly used unfiltered NY run IDs:\n{output}"
+    )
+
+
+def test_sync_check_cannot_determine_when_state_missing_from_one_side(
+    tmp_path: Path,
+) -> None:
+    """S3 has no MD run at all → sync status should be indeterminate."""
+    ebs_base = str(tmp_path)
+    sb_dir = tmp_path / "res_2024_amy2018_2_sb"
+
+    md_run = _make_run("run-MD-001", ["MD"], ["0", "2"])
+    finish_run(md_run)
+    upsert_run(sb_dir, md_run)
+
+    # S3 has only a NY run
+    ny_run = _fake_s3_manifest([_make_run("run-NY-001", ["NY"], ["0", "2"])])
+
+    with patch(
+        "data.resstock.manifest.read_manifest_from_s3",
+        return_value=ny_run,
+    ):
+        output = _capture_status(
+            release="res_2024_amy2018_2",
+            release_sb="res_2024_amy2018_2_sb",
+            ebs_base=ebs_base,
+            s3_base="s3://data.sb/nrel/resstock",
+            states=["MD"],
+            variant="sb",
+        )
+
+    assert "cannot determine sync" in output, (
+        f"Expected indeterminate sync message:\n{output}"
+    )
+
+
+# ── _filter_runs unit tests ───────────────────────────────────────────────────
+
+
+def test_filter_runs_by_state() -> None:
+    md = _make_run("r1", ["MD"], ["0"])
+    ny = _make_run("r2", ["NY"], ["0"])
+    assert _filter_runs([md, ny], states=["MD"]) == [md]
+    assert _filter_runs([md, ny], states=["NY"]) == [ny]
+    assert _filter_runs([md, ny], states=["RI"]) == []
+
+
+def test_filter_runs_by_upgrade() -> None:
+    u0 = _make_run("r1", ["MD"], ["0"])
+    u2 = _make_run("r2", ["MD"], ["2"])
+    assert _filter_runs([u0, u2], upgrades=["0"]) == [u0]
+    assert _filter_runs([u0, u2], upgrades=["2"]) == [u2]
+    assert _filter_runs([u0, u2], upgrades=["5"]) == []
+
+
+def test_filter_runs_no_filter_returns_all() -> None:
+    runs = [_make_run(f"r{i}", ["MD"], ["0"]) for i in range(3)]
+    assert _filter_runs(runs) == runs

--- a/tests/test_resstock_manifest.py
+++ b/tests/test_resstock_manifest.py
@@ -276,3 +276,273 @@ def test_filter_runs_by_upgrade() -> None:
 def test_filter_runs_no_filter_returns_all() -> None:
     runs = [_make_run(f"r{i}", ["MD"], ["0"]) for i in range(3)]
     assert _filter_runs(runs) == runs
+
+
+# ── Integrity check ──────────────────────────────────────────────────────────
+
+
+def test_check_integrity_unions_file_types_across_runs(tmp_path: Path) -> None:
+    """Expected types are the union of all matching runs, not just the latest."""
+    import time
+
+    from data.resstock.manifest import check_integrity
+
+    ebs_base = str(tmp_path)
+    release = "res_2024_amy2018_2"
+    raw_dir = tmp_path / release
+    sb_dir = tmp_path / f"{release}_sb"
+    sb_dir.mkdir(parents=True)
+
+    # Files from two separate runs: metadata then load_curve_hourly
+    for d in (
+        raw_dir / "metadata" / "state=MD" / "upgrade=00",
+        raw_dir / "load_curve_hourly" / "state=MD" / "upgrade=00",
+    ):
+        d.mkdir(parents=True)
+        (d / "data.parquet").write_bytes(b"ok")
+    time.sleep(0.05)
+
+    run1 = _make_run("run-meta", ["MD"], ["0"])
+    run1["args"]["file_types"] = ["metadata"]
+    record_step(run1, "fetch")
+    finish_run(run1)
+    upsert_run(raw_dir, run1)
+
+    run2 = _make_run("run-loads", ["MD"], ["0"])
+    run2["args"]["file_types"] = ["load_curve_hourly"]
+    record_step(run2, "fetch")
+    finish_run(run2)
+    upsert_run(raw_dir, run2)
+
+    # Empty _sb manifest so it doesn't confuse the raw assertion
+    sb_run = _make_run("run-sb", ["MD"], ["0"])
+    sb_run["args"]["file_types"] = ["metadata"]
+    finish_run(sb_run)
+    upsert_run(sb_dir, sb_run)
+
+    with patch("data.resstock.manifest._list_s3_files", return_value=[]):
+        report = check_integrity(
+            release=release,
+            state="MD",
+            ebs_base=ebs_base,
+            s3_base="s3://data.sb/nrel/resstock",
+            location="ebs",
+            output_path=tmp_path / "report.yaml",
+        )
+
+    raw_issues = [
+        m
+        for m in report["mismatches"]
+        if m.get("release") == release
+        and m.get("issue")
+        in (
+            "unexpected_file_type",
+            "missing_file_type",
+        )
+    ]
+    assert raw_issues == [], (
+        f"Union of metadata + load_curve_hourly runs should expect both; "
+        f"got issues: {raw_issues}"
+    )
+
+
+def test_check_integrity_file_type_bijection_passes(tmp_path: Path) -> None:
+    """Expected file types present with matching timestamps → no mismatches."""
+    import time
+
+    from data.resstock.manifest import check_integrity
+
+    ebs_base = str(tmp_path)
+    release = "res_2024_amy2018_2"
+    release_sb = f"{release}_sb"
+    sb_dir = tmp_path / release_sb
+    raw_dir = tmp_path / release
+
+    # Create expected dirs before recording steps so mtimes precede completed_at
+    for d in (
+        sb_dir / "metadata" / "state=MD" / "upgrade=00",
+        sb_dir / "metadata_utility" / "state=MD",
+        raw_dir / "metadata" / "state=MD" / "upgrade=00",
+    ):
+        d.mkdir(parents=True)
+        (d / "data.parquet").write_bytes(b"ok")
+    time.sleep(0.05)
+
+    sb_run = _make_run("run-MD-001", ["MD"], ["0"])
+    sb_run["args"]["file_types"] = ["metadata"]
+    record_step(sb_run, "clone")
+    record_step(sb_run, "assign_utility")
+    finish_run(sb_run)
+    upsert_run(sb_dir, sb_run)
+
+    raw_run = _make_run("run-MD-001", ["MD"], ["0"])
+    raw_run["args"]["file_types"] = ["metadata"]
+    record_step(raw_run, "fetch")
+    finish_run(raw_run)
+    upsert_run(raw_dir, raw_run)
+
+    report_path = tmp_path / "report.yaml"
+    with patch("data.resstock.manifest._list_s3_files", return_value=[]):
+        report = check_integrity(
+            release=release,
+            state="MD",
+            ebs_base=ebs_base,
+            s3_base="s3://data.sb/nrel/resstock",
+            location="ebs",
+            output_path=report_path,
+        )
+
+    assert report["mismatches"] == []
+    assert "match the manifest" in report["summary"]
+    assert report_path.exists()
+
+
+def test_check_integrity_flags_unexpected_file_type_on_sb(tmp_path: Path) -> None:
+    """load_curve_annual on _sb must fail: excluded from _sb and not in expected set."""
+    from data.resstock.manifest import check_integrity
+
+    ebs_base = str(tmp_path)
+    release = "res_2024_amy2018_2"
+    release_sb = f"{release}_sb"
+    sb_dir = tmp_path / release_sb
+    raw_dir = tmp_path / release
+
+    # Expected types for _sb with these steps: metadata, load_curve_hourly, metadata_utility
+    for d in (
+        sb_dir / "metadata" / "state=MD" / "upgrade=00",
+        sb_dir / "load_curve_hourly" / "state=MD" / "upgrade=00",
+        sb_dir / "metadata_utility" / "state=MD",
+        # Forbidden leftover:
+        sb_dir / "load_curve_annual" / "state=MD" / "upgrade=00",
+    ):
+        d.mkdir(parents=True)
+        (d / "data.parquet").write_bytes(b"x")
+
+    sb_run = _make_run("run-MD-001", ["MD"], ["0"])
+    sb_run["args"]["file_types"] = [
+        "metadata",
+        "load_curve_hourly",
+        "load_curve_annual",
+    ]
+    record_step(sb_run, "clone")
+    record_step(sb_run, "assign_utility")
+    finish_run(sb_run)
+    upsert_run(sb_dir, sb_run)
+
+    # Raw: no files needed for this assertion (will report missing, that's fine —
+    # we only assert on the unexpected_file_type for load_curve_annual on _sb)
+    raw_run = _make_run("run-MD-001", ["MD"], ["0"])
+    raw_run["args"]["file_types"] = ["metadata"]
+    finish_run(raw_run)
+    upsert_run(raw_dir, raw_run)
+
+    with patch("data.resstock.manifest._list_s3_files", return_value=[]):
+        report = check_integrity(
+            release=release,
+            state="MD",
+            ebs_base=ebs_base,
+            s3_base="s3://data.sb/nrel/resstock",
+            location="ebs",
+            output_path=tmp_path / "report.yaml",
+        )
+
+    unexpected = [
+        m
+        for m in report["mismatches"]
+        if m.get("issue") == "unexpected_file_type"
+        and m.get("file_type") == "load_curve_annual"
+    ]
+    assert unexpected, f"Expected unexpected_file_type for load_curve_annual:\n{report}"
+
+
+def test_check_integrity_flags_missing_file_type(tmp_path: Path) -> None:
+    """Manifest expects metadata but directory is absent → missing_file_type."""
+    from data.resstock.manifest import check_integrity
+
+    ebs_base = str(tmp_path)
+    release = "res_2024_amy2018_2"
+    sb_dir = tmp_path / f"{release}_sb"
+    raw_dir = tmp_path / release
+    sb_dir.mkdir(parents=True)
+    raw_dir.mkdir(parents=True)
+
+    sb_run = _make_run("run-MD-001", ["MD"], ["0"])
+    sb_run["args"]["file_types"] = ["metadata", "load_curve_hourly"]
+    record_step(sb_run, "clone")
+    finish_run(sb_run)
+    upsert_run(sb_dir, sb_run)
+
+    raw_run = _make_run("run-MD-001", ["MD"], ["0"])
+    raw_run["args"]["file_types"] = ["metadata"]
+    finish_run(raw_run)
+    upsert_run(raw_dir, raw_run)
+
+    with patch("data.resstock.manifest._list_s3_files", return_value=[]):
+        report = check_integrity(
+            release=release,
+            state="MD",
+            ebs_base=ebs_base,
+            s3_base="s3://data.sb/nrel/resstock",
+            location="ebs",
+            output_path=tmp_path / "report.yaml",
+        )
+
+    missing = [
+        m
+        for m in report["mismatches"]
+        if m.get("issue") == "missing_file_type" and m.get("release") == f"{release}_sb"
+    ]
+    assert any(m["file_type"] == "metadata" for m in missing)
+    assert any(m["file_type"] == "load_curve_hourly" for m in missing)
+
+
+def test_check_integrity_flags_timestamp_mismatch(tmp_path: Path) -> None:
+    """Newest file mtime after the step completed_at (+ tolerance) → timestamp_mismatch."""
+    import os
+    import time
+
+    from data.resstock.manifest import check_integrity
+
+    ebs_base = str(tmp_path)
+    release = "res_2024_amy2018_2"
+    release_sb = f"{release}_sb"
+    sb_dir = tmp_path / release_sb
+    raw_dir = tmp_path / release
+
+    sb_run = _make_run("run-MD-001", ["MD"], ["0"])
+    sb_run["args"]["file_types"] = ["metadata"]
+    record_step(sb_run, "clone")
+    record_step(sb_run, "assign_utility")
+    finish_run(sb_run)
+    upsert_run(sb_dir, sb_run)
+
+    raw_run = _make_run("run-MD-001", ["MD"], ["0"])
+    raw_run["args"]["file_types"] = ["metadata"]
+    finish_run(raw_run)
+    upsert_run(raw_dir, raw_run)
+
+    # Create files AFTER the step timestamps, with future mtime
+    for d in (
+        sb_dir / "metadata" / "state=MD" / "upgrade=00",
+        sb_dir / "metadata_utility" / "state=MD",
+    ):
+        d.mkdir(parents=True)
+        f = d / "data.parquet"
+        f.write_bytes(b"late")
+        os.utime(f, (time.time() + 3600, time.time() + 3600))
+
+    with patch("data.resstock.manifest._list_s3_files", return_value=[]):
+        report = check_integrity(
+            release=release,
+            state="MD",
+            ebs_base=ebs_base,
+            s3_base="s3://data.sb/nrel/resstock",
+            location="ebs",
+            tolerance_seconds=300,
+            output_path=tmp_path / "report.yaml",
+        )
+
+    ts_issues = [
+        m for m in report["mismatches"] if m.get("issue") == "timestamp_mismatch"
+    ]
+    assert ts_issues, f"Expected timestamp_mismatch:\n{report}"

--- a/tests/test_resstock_utils.py
+++ b/tests/test_resstock_utils.py
@@ -1,0 +1,129 @@
+"""Tests for data/resstock/utils.py — specifically upload() error behavior.
+
+The upload() function was changed to raise RuntimeError when any
+``aws s3 sync`` command exits with a non-zero code, rather than
+silently printing a WARNING and continuing.  Two key guarantees:
+
+1. All (file_type, state) combinations are attempted even if an
+   earlier one fails, so a partial failure does not silently skip the
+   remaining uploads.
+2. After all combinations are tried, a single RuntimeError is raised
+   that lists every failed combination.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from data.resstock.utils import upload
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _sync_result(returncode: int) -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    return m
+
+
+# ── upload() error-handling tests ────────────────────────────────────────────
+
+
+def test_upload_raises_on_single_failure(tmp_path: Path) -> None:
+    """RuntimeError is raised when aws s3 sync returns non-zero for one combo."""
+    (tmp_path / "rel" / "metadata" / "state=MD").mkdir(parents=True)
+
+    with patch("subprocess.run", return_value=_sync_result(1)) as mock_run:
+        with pytest.raises(RuntimeError, match="1 combination"):
+            upload(
+                state=["MD"],
+                file_types=["metadata"],
+                release="rel",
+                path_output_dir=tmp_path,
+                path_s3_dir="s3://data.sb/nrel/resstock",
+            )
+    assert mock_run.call_count == 1
+
+
+def test_upload_raises_listing_all_failures(tmp_path: Path) -> None:
+    """All failed combos are listed in the RuntimeError, not just the first."""
+    for ft in ("metadata", "load_curve_hourly"):
+        (tmp_path / "rel" / ft / "state=MD").mkdir(parents=True)
+
+    # Both combos fail
+    with patch("subprocess.run", return_value=_sync_result(1)):
+        with pytest.raises(RuntimeError) as exc_info:
+            upload(
+                state=["MD"],
+                file_types=["metadata", "load_curve_hourly"],
+                release="rel",
+                path_output_dir=tmp_path,
+                path_s3_dir="s3://data.sb/nrel/resstock",
+            )
+
+    msg = str(exc_info.value)
+    assert "2 combination" in msg
+    assert "metadata" in msg
+    assert "load_curve_hourly" in msg
+
+
+def test_upload_attempts_all_combos_despite_earlier_failure(tmp_path: Path) -> None:
+    """Even when the first combination fails, all remaining combos are attempted."""
+    for ft in ("metadata", "load_curve_hourly"):
+        (tmp_path / "rel" / ft / "state=MD").mkdir(parents=True)
+
+    # First call fails, second succeeds
+    results = [_sync_result(1), _sync_result(0)]
+    with patch("subprocess.run", side_effect=results) as mock_run:
+        with pytest.raises(RuntimeError, match="1 combination"):
+            upload(
+                state=["MD"],
+                file_types=["metadata", "load_curve_hourly"],
+                release="rel",
+                path_output_dir=tmp_path,
+                path_s3_dir="s3://data.sb/nrel/resstock",
+            )
+
+    # Both combos were attempted
+    assert mock_run.call_count == 2
+
+
+def test_upload_does_not_raise_on_all_success(tmp_path: Path) -> None:
+    """No exception is raised when all aws s3 sync commands succeed."""
+    (tmp_path / "rel" / "metadata" / "state=MD").mkdir(parents=True)
+
+    with patch("subprocess.run", return_value=_sync_result(0)):
+        upload(
+            state=["MD"],
+            file_types=["metadata"],
+            release="rel",
+            path_output_dir=tmp_path,
+            path_s3_dir="s3://data.sb/nrel/resstock",
+        )
+
+
+def test_upload_invokes_correct_s3_paths(tmp_path: Path) -> None:
+    """aws s3 sync is called with the expected local and S3 paths."""
+    (tmp_path / "rel" / "metadata" / "state=MD").mkdir(parents=True)
+    expected_local = str(tmp_path / "rel" / "metadata" / "state=MD")
+    expected_s3 = "s3://data.sb/nrel/resstock/rel/metadata/state=MD/"
+
+    with patch("subprocess.run", return_value=_sync_result(0)) as mock_run:
+        upload(
+            state=["MD"],
+            file_types=["metadata"],
+            release="rel",
+            path_output_dir=tmp_path,
+            path_s3_dir="s3://data.sb/nrel/resstock",
+        )
+
+    invoked_cmd = mock_run.call_args[0][0]
+    assert invoked_cmd[0] == "aws"
+    assert invoked_cmd[1] == "s3"
+    assert invoked_cmd[2] == "sync"
+    assert invoked_cmd[3] == expected_local
+    assert invoked_cmd[4] == expected_s3


### PR DESCRIPTION
## Summary

This PR adds script to correctly track the `*_sb` release files via manifest and track files that were updated manually and not via the proper ResStock data prep pipeline.

Closes #484 