### PR TITLE
Add Prefect-native master bills/BAT builders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,28 +39,36 @@ The main outputs are calibrated tariffs (when CAIRO is run in pre-calc mode), cu
 
 ### Master tables (cross-utility, post-processed)
 
-After individual CAIRO runs complete, post-processing scripts consolidate results across all utilities in a batch into **master tables** at `s3://data.sb/switchbox/cairo/outputs/hp_rates/<state>/all_utilities/<batch>/run_<delivery>+<supply>/`. These are Hive-partitioned Parquet datasets (partitioned by `sb.electric_utility`) and are the primary data source for analysis notebooks and reports.
+After individual CAIRO runs complete, post-processing scripts consolidate results across all utilities in a batch into **master tables** at `s3://data.sb/switchbox/cairo/outputs/hp_rates/<state>/all_utilities/<batch>/<segment>/`. These are Hive-partitioned Parquet datasets (partitioned by `sb.electric_utility`) and are the primary data source for analysis notebooks and reports.
 
-**Master bills** (`comb_bills_year_target/`) — one row per building per month (Jan–Dec + Annual). Created by `utils/post/build_master_bills.py`, invoked via `just build-master-bills <batch> <run_delivery> <run_supply>`. Combines the delivery-only run's `comb_bills_year_target.csv` (for electric delivery and gas/propane/oil bills) with the delivery+supply run's electric supply bills. Joins ResStock metadata (`metadata_sb`, `utility_assignment`) for building attributes.
+`<segment>` identifies which runs the table came from, and depends on which orchestrator produced the batch:
 
-| Column                                                                        | Description                                     |
-| ----------------------------------------------------------------------------- | ----------------------------------------------- |
-| bldg_id                                                                       | ResStock building identifier                    |
-| sb.electric_utility, sb.gas_utility                                           | Utility assignments                             |
-| upgrade                                                                       | ResStock upgrade ID (0 = baseline, 2 = HP)      |
-| postprocess_group.has_hp, postprocess_group.heating_type                      | HP status and heating classification            |
-| heats_with_electricity, heats_with_natgas, heats_with_oil, heats_with_propane | Fuel flags                                      |
-| month                                                                         | "Jan"–"Dec" or "Annual"                         |
-| weight                                                                        | CAIRO sample weight                             |
-| elec_fixed_charge                                                             | Electric fixed charge component                 |
-| elec_delivery_bill                                                            | Electric delivery volumetric bill               |
-| elec_supply_bill                                                              | Electric supply bill (from supply run)          |
-| elec_total_bill                                                               | Total electric bill (fixed + delivery + supply) |
-| gas_total_bill                                                                | Total gas bill                                  |
-| propane_total_bill, oil_total_bill                                            | Delivered fuel bills                            |
-| energy_total_bill                                                             | Sum of all fuel bills                           |
+- **Prefect pipeline** (current): `<scenario>_<stage>`, e.g. `default_precalc`, `hp_seasonal_percustomer_passthrough_calibrated`. One `just s <state> build-all-master-prefect <batch>` builds every segment in the batch, via `utils/post/build_master_bills_prefect.py` and `utils/post/build_master_bat_prefect.py`. See `context/code/orchestration/prefect_pipeline.md` for run discovery, the `baseline_elec_*` columns, and why calibrated-segment BAT should not be read as cross-subsidy.
+- **Legacy Justfile** (older batches): `run_<delivery>+<supply>`, one invocation per run pair.
 
-**Master BAT** (`cross_subsidization_BAT_values/`) — one row per building (annual). Created by `utils/post/build_master_bat.py`, invoked via `just build-master-bat <batch> <run_delivery> <run_supply>`. Computes delivery, supply, and total bill alignment by taking the delivery-only run's BAT values as delivery, the delivery+supply run's values as total, and deriving supply = total − delivery.
+Either way, a segment joins a **delivery** run with its paired **supply** run: electric delivery (and gas/oil/propane) figures come from the delivery-only run, electric supply from the delivery+supply run.
+
+**Master bills** (`comb_bills_year_target/`) — one row per building per month (Jan–Dec + Annual). Combines the delivery-only run's `comb_bills_year_target.csv` (for electric delivery and gas/propane/oil bills) with the delivery+supply run's electric supply bills. Joins ResStock metadata (`metadata_sb`, `utility_assignment`) for building attributes; the Prefect builder always takes those attributes from the baseline upgrade, so pre-retrofit heating type stays sliceable. Legacy invocation: `just build-master-bills <batch> <run_delivery> <run_supply>`.
+
+| Column                                                                             | Description                                                                         |
+| ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| bldg_id                                                                            | ResStock building identifier                                                        |
+| sb.electric_utility, sb.gas_utility                                                | Utility assignments                                                                 |
+| upgrade                                                                            | ResStock upgrade ID (0 = baseline, 2 = HP)                                          |
+| postprocess_group.has_hp, postprocess_group.heating_type                           | HP status and heating classification                                                |
+| heats_with_electricity, heats_with_natgas, heats_with_oil, heats_with_propane      | Fuel flags                                                                          |
+| month                                                                              | "Jan"–"Dec" or "Annual"                                                             |
+| weight                                                                             | CAIRO sample weight                                                                 |
+| elec_fixed_charge                                                                  | Electric fixed charge component                                                     |
+| elec_delivery_bill                                                                 | Electric delivery volumetric bill                                                   |
+| elec_supply_bill                                                                   | Electric supply bill (from supply run)                                              |
+| elec_total_bill                                                                    | Total electric bill (fixed + delivery + supply)                                     |
+| baseline_elec_fixed_charge, baseline_elec_delivery_bill, baseline_elec_supply_bill | Same components under the baseline segment (Prefect batches only), for bill changes |
+| gas_total_bill                                                                     | Total gas bill                                                                      |
+| propane_total_bill, oil_total_bill                                                 | Delivered fuel bills                                                                |
+| energy_total_bill                                                                  | Sum of all fuel bills                                                               |
+
+**Master BAT** (`cross_subsidization_BAT_values/`) — one row per building (annual). Computes delivery, supply, and total bill alignment by taking the delivery-only run's BAT values as delivery, the delivery+supply run's values as total, and deriving supply = total − delivery. Also carries the cost-allocation components BAT is derived from (`annual_bill_*`, `economic_burden_*`, `residual_share_*`) and the same `baseline_elec_*` columns as master bills, which it reads from the baseline segment's master bills — so build bills first. Legacy invocation: `just build-master-bat <batch> <run_delivery> <run_supply>`.
 
 | Column                                                                        | Description                                           |
 | ----------------------------------------------------------------------------- | ----------------------------------------------------- |

--- a/context/code/orchestration/prefect_pipeline.md
+++ b/context/code/orchestration/prefect_pipeline.md
@@ -183,11 +183,14 @@ scenarios:
     residual_allocation:
       delivery: percustomer
       supply: passthrough
-    subclass_config:
-      group_col: has_hp
-      subgroups:
-        hp:   { values: ["true"],  structure: seasonal }
+      subclass_config:
+        group_col: has_hp
+        subgroups:
+          hp:   { values: ["true"],  structure: seasonal }
         non-hp: { values: ["false"], structure: base }
+bill_change_baseline:
+  scenario: default
+  stage: precalc
 ```
 
 ### Key config fields
@@ -197,6 +200,7 @@ scenarios:
 - `periods_yaml` — utility periods config (winter months); defaults to `periods/{utility}.yaml`
 - `depends_on` — names the dependency scenario whose outputs feed `derive_tariffs`
 - `promote` — which subgroup's calibrated tariff to promote for `multi_rate_collapsed`
+- `bill_change_baseline` — the one `(scenario, stage)` every run's bills are compared against. Read only by post-processing, so the pipeline runs without it; the master-table builders raise if it is missing. It is a single stage, not a quartet: usually `default` + `precalc`, i.e. today's rates on the pre-upgrade population.
 
 ## Invocation
 
@@ -236,6 +240,59 @@ uv run python -m rate_design.hp_rates.run_pipeline \
 ```
 
 The `--scenarios` filter restricts which scenarios run (preflight is also scoped). Omit for all.
+
+## Post-processing: master tables
+
+Once a batch finishes, two builders consolidate its CAIRO outputs into the master tables that notebooks and reports read. They are plain CLIs driven by Just — not Prefect flows — and one invocation covers a whole batch:
+
+```bash
+cd rate_design/hp_rates
+just s md build-all-master-prefect md_20260803_a
+```
+
+That runs bills then BAT (in that order, because BAT joins the baseline bills). Either can be run alone with `build-master-bills-prefect` / `build-master-bat-prefect`, and both accept `--scenarios` to narrow the work.
+
+| Script                                     | Output                            | Grain             |
+| ------------------------------------------ | --------------------------------- | ----------------- |
+| `utils/post/build_master_bills_prefect.py` | `comb_bills_year_target/`         | building × month  |
+| `utils/post/build_master_bat_prefect.py`   | `cross_subsidization_BAT_values/` | building (annual) |
+
+### One master table per segment
+
+A **segment** is one `{scenario}_{stage}` pair — `default_precalc`, `hp_seasonal_percustomer_passthrough_calibrated`, and so on. Each becomes its own master table, written twice: once per utility and once for the batch:
+
+```
+{output_base}/{state}/{utility}/{batch}/{segment}/{table}/
+{output_base}/{state}/all_utilities/{batch}/{segment}/{table}/
+```
+
+The `all_utilities` copy is Hive-partitioned by `sb.electric_utility` and is what analysis reads. This replaces the legacy Justfile layout, which keyed tables by `run_{delivery}+{supply}` and needed one invocation per run pair.
+
+The delivery and supply runs of a segment are **joined**, not kept separate: the delivery-only run supplies electric delivery (and gas/oil/propane) figures, the delivery+supply run supplies electric supply, and supply-only BAT is derived as `total − delivery`.
+
+### Run discovery
+
+Builders never take run numbers. For each utility they load `{state}/config/scenarios/pipeline_{utility}.yaml` by convention, expand its scenarios into segments, and look up each run's output directory in the batch's run index (`{batch_dir}/.runs/{canonical_run_name}.path`). Index files hold FUSE paths, which `utils/post/pipeline_runs.py` maps to `s3://` URIs.
+
+A segment whose **both** variants are missing is skipped with a log line, so a partially-run batch still post-processes. A segment with **one** variant missing raises: that table can never be built, and skipping it would hide a failed CAIRO run.
+
+### Baseline bill columns
+
+Every row in both tables carries the baseline segment's annual electric bill, so bill changes can be computed without a second read:
+
+`baseline_elec_fixed_charge`, `baseline_elec_delivery_bill`, `baseline_elec_supply_bill`
+
+The baseline segment comes from `bill_change_baseline` in the pipeline YAML, and its table is built first so the others can join it. On the baseline segment itself, the columns are copies of its own `elec_*` values. The builders assert that the baseline table's `upgrade` matches the upgrade its configured stage implies, so a mismatched or stale baseline fails loudly instead of silently attaching the wrong bills.
+
+Building BAT without the baseline bills raises with the path to build first — hence `build-all-master-prefect`.
+
+### Building attributes come from upgrade 00
+
+`postprocess_group.has_hp`, `postprocess_group.heating_type`, the `heats_with_*` flags, income, and cooling are read from the **baseline** upgrade's `metadata-sb.parquet` on every segment, joined to `utility_assignment.parquet` for the utility mapping. ResStock marks every building in the heat-pump upgrade as a heat pump, so a calibrated segment's own metadata would erase what the home heated with before the retrofit — the dimension most analyses slice on. The `upgrade` column identifies the stage instead.
+
+### Reading the BAT tables
+
+BAT metrics in **calibrated** segments are dominated by the deliberately large revenue requirement those runs use (`residual_share_total` lands in the hundreds of thousands per customer, versus roughly a thousand in precalc). Bills in calibrated segments are unaffected and correct. The builders write what CAIRO produced without special-casing; interpret cross-subsidy metrics from precalc segments.
 
 ## Derived path anatomy
 

--- a/rate_design/hp_rates/Justfile
+++ b/rate_design/hp_rates/Justfile
@@ -1453,6 +1453,39 @@ build-master-bat batch run_delivery run_supply *batch_overrides:
 # per-utility batch overrides (for example, --batch-override cenhud=ny_20260306_r1-8)
 # and optional LMI flags (for example, --calculate-lmi --lmi-participation-rate 0.4).
 
+# =============================================================================
+# POST-PROCESSING: master tables for Prefect pipeline batches
+#
+# One command covers a whole batch: every scenario/stage in each utility's
+# pipeline YAML becomes its own master table under {scenario}_{stage}/.
+# Runs are discovered from the batch's .runs/ index, so no run numbers.
+#
+#   just s md build-master-bills-prefect md_20260803_a
+#   just s md build-all-master-prefect md_20260803_a
+# =============================================================================
+
+# Build master bills for every completed scenario/stage in a Prefect batch.
+build-master-bills-prefect batch *script_args:
+    uv run python {{ path_repo }}/utils/post/build_master_bills_prefect.py \
+        --state "{{ state }}" \
+        --batch "{{ batch }}" \
+        --utilities "{{ utilities }}" \
+        --path-heating-fuel-prices "{{ path_heating_fuel_prices }}" \
+        --price-year "{{ price_year }}" \
+        {{ script_args }}
+
+# Build master BAT for a Prefect batch (needs the baseline segment's master bills).
+build-master-bat-prefect batch *script_args:
+    uv run python {{ path_repo }}/utils/post/build_master_bat_prefect.py \
+        --state "{{ state }}" \
+        --batch "{{ batch }}" \
+        --utilities "{{ utilities }}" \
+        {{ script_args }}
+
+# Both master tables for a batch, bills first (BAT joins the baseline bills).
+build-all-master-prefect batch: (build-master-bills-prefect batch) (build-master-bat-prefect batch)
+    @echo ">> Master bills and BAT complete for batch {{ batch }}" >&2
+
 validate-master-bills batch filter *batch_overrides:
     uv run python {{ path_repo }}/utils/post/validate_master_bills.py \
         --state "{{ state }}" \

--- a/rate_design/hp_rates/md/config/scenarios/pipeline_bge.yaml
+++ b/rate_design/hp_rates/md/config/scenarios/pipeline_bge.yaml
@@ -45,3 +45,8 @@ scenarios:
         non-hp:
           values: ["false"]
           structure: base
+# The one stage every other run's bills are compared against, joined onto the
+# master tables as baseline_elec_* columns by post-processing.
+bill_change_baseline:
+  scenario: default
+  stage: precalc

--- a/rate_design/hp_rates/pipeline_config.py
+++ b/rate_design/hp_rates/pipeline_config.py
@@ -121,6 +121,25 @@ class ScenarioConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class BillChangeBaseline:
+    """The (scenario, stage) pair that bill changes are measured against.
+
+    Post-processing joins this run's electric bills onto every other run as
+    ``baseline_elec_*`` columns.  It is one stage of one scenario, not a whole
+    quartet: the usual choice is the ``default`` scenario's ``precalc`` stage,
+    i.e. today's rates applied to the pre-upgrade population.
+    """
+
+    scenario: str
+    stage: str
+
+    @property
+    def segment(self) -> str:
+        """The ``{scenario}_{stage}`` master-table folder holding the baseline."""
+        return f"{self.scenario}_{self.stage}"
+
+
+@dataclass(frozen=True, slots=True)
 class RunDefaults:
     """Batch-level fields passed through to the generated scenario YAML.
 
@@ -170,6 +189,10 @@ class PipelineConfig:
 
     scenarios: dict[str, ScenarioConfig]
     run_defaults: RunDefaults
+
+    # Read only by post-processing (master bills / master BAT), so the pipeline
+    # runs fine without it; the builders raise if it is missing.
+    bill_change_baseline: BillChangeBaseline | None = None
 
     @property
     def state_config_dir(self) -> Path:
@@ -338,6 +361,9 @@ def load_pipeline_config(yaml_path: Path) -> PipelineConfig:
         output_base=data["output_base"],
         scenarios=scenarios,
         run_defaults=run_defaults,
+        bill_change_baseline=_parse_bill_change_baseline(
+            data.get("bill_change_baseline"), scenarios
+        ),
     )
 
 
@@ -380,6 +406,36 @@ def _parse_subclass_config(raw: dict[str, Any] | None) -> SubclassConfig | None:
         for alias, spec in subgroups_raw.items()
     ]
     return SubclassConfig(group_col=str(raw["group_col"]), subgroups=subgroups)
+
+
+def _parse_bill_change_baseline(
+    raw: dict[str, Any] | None,
+    scenarios: dict[str, ScenarioConfig],
+) -> BillChangeBaseline | None:
+    """Parse and validate the optional ``bill_change_baseline`` block."""
+    if raw is None:
+        return None
+
+    missing = [key for key in ("scenario", "stage") if key not in raw]
+    if missing:
+        raise ValueError(
+            f"bill_change_baseline is missing required key(s): {', '.join(missing)}"
+        )
+
+    scenario = str(raw["scenario"])
+    if scenario not in scenarios:
+        raise ValueError(
+            f"bill_change_baseline.scenario {scenario!r} is not a declared "
+            f"scenario; available: {sorted(scenarios)}"
+        )
+
+    stage = str(raw["stage"])
+    if stage not in _STAGES:
+        raise ValueError(
+            f"bill_change_baseline.stage {stage!r} must be one of {list(_STAGES)}"
+        )
+
+    return BillChangeBaseline(scenario=scenario, stage=stage)
 
 
 def _validate_scenario(scenario: ScenarioConfig) -> None:

--- a/rate_design/hp_rates/ri/config/scenarios/pipeline_rie.yaml
+++ b/rate_design/hp_rates/ri/config/scenarios/pipeline_rie.yaml
@@ -43,3 +43,8 @@ scenarios:
         non-hp:
           values: ["false"]
           structure: base
+# The one stage every other run's bills are compared against, joined onto the
+# master tables as baseline_elec_* columns by post-processing.
+bill_change_baseline:
+  scenario: default
+  stage: precalc

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -1,0 +1,128 @@
+"""Tests for the pipeline YAML loader (rate_design/hp_rates/pipeline_config.py)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from rate_design.hp_rates.pipeline_config import (
+    load_pipeline_config,
+    validate_preflight_inputs,
+)
+
+
+def _minimal_pipeline_yaml() -> dict[str, Any]:
+    """Smallest pipeline YAML that parses, for exercising orchestration fields."""
+    return {
+        "state": "md",
+        "utility": "bge",
+        "year": 2025,
+        "output_base": "/data.sb/switchbox/cairo/outputs/hp_rates",
+        "process_workers": 8,
+        "max_concurrent_cairo_runs": 2,
+        "resstock": {
+            "base": "/ebs/data/nrel/resstock/res_2024_amy2018_2_sb",
+            "upgrade_precalc": "00",
+            "upgrade_calibrated": "02",
+        },
+        "marginal_costs": {
+            "dist_and_sub_tx": "s3://bucket/dist/data.parquet",
+            "bulk_tx": "s3://bucket/bulk/data.parquet",
+            "supply_energy": "s3://bucket/energy/data.parquet",
+            "supply_capacity": "s3://bucket/capacity/data.parquet",
+        },
+        "revenue_requirement": {
+            "single_rate": "rev_requirement/bge.yaml",
+            "single_rate_calibrated": "rev_requirement/bge_large.yaml",
+            "multi_rate_calibrated": "rev_requirement/bge_large.yaml",
+        },
+        "scenarios": {
+            "default": {"quartet": "single_rate", "tariff_base": "default"},
+        },
+    }
+
+
+def _write(tmp_path: Path, data: dict[str, Any]) -> Path:
+    path = tmp_path / "pipeline_test.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return path
+
+
+class TestConcurrentVariants:
+    """`concurrent_variants` toggles delivery/supply overlap within a stage."""
+
+    def test_defaults_to_sequential_when_absent(self, tmp_path: Path) -> None:
+        config = load_pipeline_config(_write(tmp_path, _minimal_pipeline_yaml()))
+        assert config.concurrent_variants is False
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_explicit_value_is_respected(self, tmp_path: Path, value: bool) -> None:
+        data = _minimal_pipeline_yaml()
+        data["concurrent_variants"] = value
+        config = load_pipeline_config(_write(tmp_path, data))
+        assert config.concurrent_variants is value
+
+
+class TestBillChangeBaseline:
+    """`bill_change_baseline` is post-processing-only, so optional at load."""
+
+    def test_absent_block_parses_to_none(self, tmp_path: Path) -> None:
+        config = load_pipeline_config(_write(tmp_path, _minimal_pipeline_yaml()))
+        assert config.bill_change_baseline is None
+
+    def test_valid_block_parses(self, tmp_path: Path) -> None:
+        data = _minimal_pipeline_yaml()
+        data["bill_change_baseline"] = {"scenario": "default", "stage": "precalc"}
+        config = load_pipeline_config(_write(tmp_path, data))
+        baseline = config.bill_change_baseline
+        assert baseline is not None
+        assert (baseline.scenario, baseline.stage) == ("default", "precalc")
+        assert baseline.segment == "default_precalc"
+
+    def test_unknown_scenario_is_rejected(self, tmp_path: Path) -> None:
+        data = _minimal_pipeline_yaml()
+        data["bill_change_baseline"] = {"scenario": "nope", "stage": "precalc"}
+        with pytest.raises(ValueError, match="not a declared scenario"):
+            load_pipeline_config(_write(tmp_path, data))
+
+    def test_unknown_stage_is_rejected(self, tmp_path: Path) -> None:
+        data = _minimal_pipeline_yaml()
+        data["bill_change_baseline"] = {"scenario": "default", "stage": "final"}
+        with pytest.raises(ValueError, match="must be one of"):
+            load_pipeline_config(_write(tmp_path, data))
+
+    def test_missing_key_is_rejected(self, tmp_path: Path) -> None:
+        data = _minimal_pipeline_yaml()
+        data["bill_change_baseline"] = {"scenario": "default"}
+        with pytest.raises(ValueError, match="missing required key"):
+            load_pipeline_config(_write(tmp_path, data))
+
+
+class TestFuseMountCheck:
+    """`validate_preflight_inputs` must fail fast when /data.sb is not mounted."""
+
+    def test_error_when_data_sb_not_mounted(self, tmp_path: Path) -> None:
+        config = load_pipeline_config(_write(tmp_path, _minimal_pipeline_yaml()))
+        with patch.object(Path, "is_mount", return_value=False):
+            errors = validate_preflight_inputs(config)
+        mount_errors = [e for e in errors if "/data.sb" in e and "mounted" in e]
+        assert len(mount_errors) == 1
+
+    def test_no_mount_error_when_mounted(self, tmp_path: Path) -> None:
+        config = load_pipeline_config(_write(tmp_path, _minimal_pipeline_yaml()))
+        with patch.object(Path, "is_mount", return_value=True):
+            errors = validate_preflight_inputs(config)
+        mount_errors = [e for e in errors if "/data.sb" in e and "mounted" in e]
+        assert len(mount_errors) == 0
+
+    def test_no_mount_check_for_local_output_base(self, tmp_path: Path) -> None:
+        data = _minimal_pipeline_yaml()
+        data["output_base"] = "/tmp/outputs"
+        config = load_pipeline_config(_write(tmp_path, data))
+        errors = validate_preflight_inputs(config)
+        mount_errors = [e for e in errors if "mounted" in e]
+        assert len(mount_errors) == 0

--- a/tests/test_post_pipeline_runs.py
+++ b/tests/test_post_pipeline_runs.py
@@ -1,0 +1,236 @@
+"""Tests for run discovery used by the Prefect master-table builders."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from rate_design.hp_rates.pipeline_config import (
+    PipelineConfig,
+    canonical_run_name,
+    load_pipeline_config,
+)
+from utils.post.baseline_bills import baseline_ref_root
+from utils.post.pipeline_runs import (
+    baseline_segment,
+    batch_dir,
+    build_order,
+    expected_segments,
+    find_run_pairs,
+    master_segment,
+    s3_uri,
+    upgrade_for_stage,
+)
+
+BATCH = "md_20260803_a"
+
+
+def _pipeline_yaml(output_base: Path) -> dict[str, Any]:
+    """Two-scenario pipeline YAML whose runs live under a local output base."""
+    return {
+        "state": "md",
+        "utility": "bge",
+        "year": 2025,
+        "output_base": str(output_base),
+        "resstock": {
+            "base": "/ebs/data/nrel/resstock/res_2024_amy2018_2_sb",
+            "upgrade_precalc": "00",
+            "upgrade_calibrated": "02",
+        },
+        "marginal_costs": {
+            "dist_and_sub_tx": "s3://bucket/dist/data.parquet",
+            "bulk_tx": "s3://bucket/bulk/data.parquet",
+            "supply_energy": "s3://bucket/energy/data.parquet",
+            "supply_capacity": "s3://bucket/capacity/data.parquet",
+        },
+        "revenue_requirement": {
+            "single_rate": "rev_requirement/bge.yaml",
+            "single_rate_calibrated": "rev_requirement/bge_large.yaml",
+            "multi_rate_calibrated": "rev_requirement/bge_large.yaml",
+        },
+        "scenarios": {
+            "default": {"quartet": "single_rate", "tariff_base": "default"},
+            "hp_seasonal": {"quartet": "single_rate", "tariff_base": "hp_seasonal"},
+        },
+        "bill_change_baseline": {"scenario": "default", "stage": "precalc"},
+    }
+
+
+def _load(tmp_path: Path, data: dict[str, Any]) -> PipelineConfig:
+    path = tmp_path / "pipeline_bge.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return load_pipeline_config(path)
+
+
+def _config(tmp_path: Path) -> PipelineConfig:
+    return _load(tmp_path, _pipeline_yaml(tmp_path / "outputs"))
+
+
+def _write_run_index(
+    config: PipelineConfig, scenario: str, stage: str, *variants: str
+) -> None:
+    """Record completed runs the way the Prefect pipeline does."""
+    runs_dir = Path(batch_dir(config, BATCH)) / ".runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    for variant in variants:
+        name = canonical_run_name(
+            config.state, config.utility, scenario, stage, variant
+        )
+        target = (
+            f"/data.sb/switchbox/cairo/outputs/hp_rates/md/bge/{BATCH}/"
+            f"20260803_120000_{name}"
+        )
+        (runs_dir / f"{name}.path").write_text(f"{target}\n", encoding="utf-8")
+
+
+class TestS3Uri:
+    """Run directories are recorded as FUSE paths but read as S3 URIs."""
+
+    def test_translates_fuse_path(self) -> None:
+        assert s3_uri("/data.sb/switchbox/cairo/x") == "s3://data.sb/switchbox/cairo/x"
+
+    def test_is_idempotent(self) -> None:
+        assert s3_uri("s3://data.sb/switchbox/x") == "s3://data.sb/switchbox/x"
+
+    def test_translates_mount_root(self) -> None:
+        assert s3_uri("/data.sb") == "s3://data.sb/"
+
+    def test_rejects_unmappable_path(self) -> None:
+        with pytest.raises(ValueError, match="Cannot map"):
+            s3_uri("/tmp/somewhere/else")
+
+
+class TestSegments:
+    """Master tables are keyed by ``{scenario}_{stage}``."""
+
+    def test_segment_name(self) -> None:
+        assert master_segment("default", "precalc") == "default_precalc"
+
+    def test_expected_segments_cover_both_stages(self, tmp_path: Path) -> None:
+        assert expected_segments(_config(tmp_path)) == [
+            "default_precalc",
+            "default_calibrated",
+            "hp_seasonal_precalc",
+            "hp_seasonal_calibrated",
+        ]
+
+    def test_expected_segments_can_be_filtered(self, tmp_path: Path) -> None:
+        segments = expected_segments(_config(tmp_path), scenarios=["hp_seasonal"])
+        assert segments == ["hp_seasonal_precalc", "hp_seasonal_calibrated"]
+
+    def test_unknown_scenario_is_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(KeyError):
+            expected_segments(_config(tmp_path), scenarios=["nope"])
+
+
+class TestUpgradeForStage:
+    """Stages are 1-1 with ResStock upgrades."""
+
+    @pytest.mark.parametrize(
+        ("stage", "upgrade"), [("precalc", "00"), ("calibrated", "02")]
+    )
+    def test_stage_maps_to_upgrade(
+        self, tmp_path: Path, stage: str, upgrade: str
+    ) -> None:
+        assert upgrade_for_stage(_config(tmp_path), stage) == upgrade
+
+    def test_unknown_stage_is_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="Unknown stage"):
+            upgrade_for_stage(_config(tmp_path), "final")
+
+
+class TestBaselineSegment:
+    """Baseline bill columns need an explicit baseline in the YAML."""
+
+    def test_reads_configured_baseline(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        assert baseline_segment(config, "pipeline_bge.yaml") == "default_precalc"
+
+    def test_missing_block_explains_the_fix(self, tmp_path: Path) -> None:
+        data = _pipeline_yaml(tmp_path / "outputs")
+        del data["bill_change_baseline"]
+        config = _load(tmp_path, data)
+        with pytest.raises(ValueError, match="bill_change_baseline"):
+            baseline_segment(config, "pipeline_bge.yaml")
+
+
+class TestFindRunPairs:
+    """Discovery pairs delivery with supply, per (scenario, stage)."""
+
+    def test_finds_complete_pair(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        _write_run_index(config, "default", "precalc", "delivery", "supply")
+
+        pairs = find_run_pairs(config, BATCH)
+
+        assert list(pairs) == ["default_precalc"]
+        pair = pairs["default_precalc"]
+        assert (pair.scenario, pair.stage, pair.upgrade) == (
+            "default",
+            "precalc",
+            "00",
+        )
+        assert pair.dir_delivery.startswith("s3://data.sb/")
+        assert pair.dir_delivery.endswith("_md_bge_default_precalc_delivery")
+        assert pair.dir_supply.endswith("_md_bge_default_precalc_supply")
+
+    def test_skips_segments_that_never_ran(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        _write_run_index(config, "default", "precalc", "delivery", "supply")
+        _write_run_index(config, "hp_seasonal", "calibrated", "delivery", "supply")
+
+        assert list(find_run_pairs(config, BATCH)) == [
+            "default_precalc",
+            "hp_seasonal_calibrated",
+        ]
+
+    def test_half_finished_pair_raises(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        _write_run_index(config, "default", "precalc", "delivery")
+
+        with pytest.raises(FileNotFoundError, match="supply run never completed"):
+            find_run_pairs(config, BATCH)
+
+    def test_empty_batch_finds_nothing(self, tmp_path: Path) -> None:
+        assert find_run_pairs(_config(tmp_path), BATCH) == {}
+
+    def test_scenario_filter_limits_discovery(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        _write_run_index(config, "default", "precalc", "delivery", "supply")
+        _write_run_index(config, "hp_seasonal", "precalc", "delivery", "supply")
+
+        pairs = find_run_pairs(config, BATCH, scenarios=["hp_seasonal"])
+
+        assert list(pairs) == ["hp_seasonal_precalc"]
+
+
+class TestBuildOrder:
+    """The baseline table has to exist before the segments that join it."""
+
+    def test_baseline_is_built_first(self) -> None:
+        segments = ["hp_seasonal_precalc", "default_precalc", "default_calibrated"]
+        assert build_order(segments, "default_precalc") == [
+            "default_precalc",
+            "hp_seasonal_precalc",
+            "default_calibrated",
+        ]
+
+    def test_absent_baseline_leaves_order_untouched(self) -> None:
+        segments = ["hp_seasonal_precalc", "hp_seasonal_calibrated"]
+        assert build_order(segments, "default_precalc") == segments
+
+
+class TestBaselineRefRoot:
+    """BAT and non-baseline bills read baseline columns from the master bills."""
+
+    def test_path_points_at_all_utilities_segment(self) -> None:
+        root = baseline_ref_root(
+            state_lower="md", output_batch=BATCH, segment="default_precalc"
+        )
+        assert root == (
+            "s3://data.sb/switchbox/cairo/outputs/hp_rates/md/all_utilities/"
+            f"{BATCH}/default_precalc/comb_bills_year_target/"
+        )

--- a/utils/post/baseline_bills.py
+++ b/utils/post/baseline_bills.py
@@ -1,0 +1,116 @@
+"""Load baseline electric bill components from a master comb-bills segment.
+
+Bill changes are measured against one (scenario, stage) declared as
+``bill_change_baseline`` in the pipeline YAML — typically today's rates on the
+pre-upgrade population.  Every master table repeats that run's electric bill
+components as ``baseline_elec_fixed_charge`` / ``baseline_elec_delivery_bill`` /
+``baseline_elec_supply_bill``, so a row carries both what a customer would pay
+under the modelled rate and what they pay today.
+
+The three columns mirror the ``elec_*`` columns exactly, so on the baseline
+segment itself they equal the row's own values.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import polars as pl
+
+from utils.post.io import ANNUAL_MONTH, BLDG_ID
+
+BASELINE_COLS = [
+    "baseline_elec_fixed_charge",
+    "baseline_elec_delivery_bill",
+    "baseline_elec_supply_bill",
+]
+
+
+def baseline_ref_root(*, state_lower: str, output_batch: str, segment: str) -> str:
+    """Hive root of the master ``comb_bills_year_target`` holding the baseline."""
+    return (
+        f"s3://data.sb/switchbox/cairo/outputs/hp_rates/{state_lower}/"
+        f"all_utilities/{output_batch}/{segment}/comb_bills_year_target/"
+    )
+
+
+def baseline_columns_from_self() -> list[pl.Expr]:
+    """Baseline columns for the baseline segment itself: copies of its own bills."""
+    return [
+        pl.col("elec_fixed_charge").alias("baseline_elec_fixed_charge"),
+        pl.col("elec_delivery_bill").alias("baseline_elec_delivery_bill"),
+        pl.col("elec_supply_bill").alias("baseline_elec_supply_bill"),
+    ]
+
+
+def load_baseline_reference_monthly(
+    *,
+    state_lower: str,
+    output_batch: str,
+    segment: str,
+    utility: str,
+    expected_upgrade: str,
+    storage_options: dict[str, str] | None,
+) -> pl.DataFrame:
+    """Per ``(bldg_id, month)``: baseline bill components for one electric utility.
+
+    *expected_upgrade* is the ResStock upgrade the baseline stage represents.
+    A segment holds exactly one upgrade, so a mismatch means the table was
+    built from a different stage than ``bill_change_baseline`` declares.
+    """
+    root = baseline_ref_root(
+        state_lower=state_lower, output_batch=output_batch, segment=segment
+    )
+    lf = pl.scan_parquet(
+        root,
+        hive_partitioning=True,
+        storage_options=storage_options,
+    )
+    q = lf.filter(pl.col("sb.electric_utility") == pl.lit(utility)).select(
+        pl.col(BLDG_ID),
+        pl.col("month"),
+        pl.col("upgrade").cast(pl.Int64),
+        *baseline_columns_from_self(),
+    )
+    df = cast(pl.DataFrame, q.collect())
+
+    if df.is_empty():
+        raise FileNotFoundError(
+            f"[{utility}] Baseline segment {segment!r} has no rows for this "
+            f"utility at {root}. Build master comb bills for the baseline first."
+        )
+
+    upgrades = set(df["upgrade"].unique().to_list())
+    if upgrades != {int(expected_upgrade)}:
+        raise AssertionError(
+            f"[{utility}] Baseline segment {segment!r} holds upgrade(s) "
+            f"{sorted(upgrades)}, expected [{int(expected_upgrade)}]. The "
+            f"baseline table was built from a different stage than "
+            f"bill_change_baseline declares."
+        )
+
+    return df.drop("upgrade")
+
+
+def load_baseline_reference_annual(
+    *,
+    state_lower: str,
+    output_batch: str,
+    segment: str,
+    utility: str,
+    expected_upgrade: str,
+    storage_options: dict[str, str] | None,
+) -> pl.DataFrame:
+    """One row per ``bldg_id`` (``month == Annual``) of baseline bill components."""
+    return (
+        load_baseline_reference_monthly(
+            state_lower=state_lower,
+            output_batch=output_batch,
+            segment=segment,
+            utility=utility,
+            expected_upgrade=expected_upgrade,
+            storage_options=storage_options,
+        )
+        .filter(pl.col("month") == pl.lit(ANNUAL_MONTH))
+        .drop("month")
+    )

--- a/utils/post/build_master_bat_prefect.py
+++ b/utils/post/build_master_bat_prefect.py
@@ -1,0 +1,760 @@
+"""Build master BAT (Bill Alignment Test) tables for a Prefect pipeline batch.
+
+Prefect-native counterpart of ``build_master_bat.py``.  Runs are discovered from
+each utility's pipeline YAML plus the batch's ``.runs/`` index instead of
+numeric run numbers, and one invocation covers every ``(scenario, stage)`` in
+the batch — each becoming its own master table.
+
+Reads CAIRO cross-subsidization outputs from each segment's paired
+delivery/supply runs and ResStock metadata to produce a Hive-partitioned parquet
+dataset (partitioned by sb.electric_utility) with BAT metrics decomposed into
+delivery, supply, and total components.
+
+Within a segment, the delivery run produces BAT values reflecting delivery-only
+bill alignment while the paired supply run produces delivery+supply (total) bill
+alignment.  The supply-only component is the column-wise delta:
+supply = total - delivery.
+
+In addition to the BAT metrics, the table includes the three cost-allocation
+components that CAIRO computes before deriving BAT:
+
+- **annual_bill** — the customer's annual electric bill (the ``Annual`` column
+  in CAIRO's output).
+- **economic_burden** — the customer's marginal-cost allocation
+  (``customer_level_economic_burden``): Σ(hourly_load × hourly_MC).
+- **residual_share** — the customer's per-customer residual-cost allocation
+  (``customer_level_residual_share_percustomer``).
+
+All three are decomposed into delivery / supply / total using the same identity
+as the BAT metrics.
+
+Outputs, one pair per ``{scenario}_{stage}`` segment:
+    per-utility:   {output_base}/{state}/{utility}/{batch}/{segment}/cross_subsidization_BAT_values/
+    all utilities: {output_base}/{state}/all_utilities/{batch}/{segment}/cross_subsidization_BAT_values/
+
+Output schema (1 row per building):
+    bldg_id, sb.electric_utility, sb.gas_utility, upgrade,
+    postprocess_group.has_hp, postprocess_group.heating_type,
+    postprocess_group.heating_type_v2,
+    heats_with_electricity, heats_with_natgas, heats_with_oil,
+    heats_with_propane, weight,
+    BAT_{m}_{delivery,supply,total} for each BAT metric present in CAIRO output,
+    {component}_{delivery,supply,total} for each cost component present,
+    baseline_elec_fixed_charge, baseline_elec_delivery_bill, baseline_elec_supply_bill
+
+Known BAT metrics: BAT_vol, BAT_peak, BAT_percustomer, BAT_epmc.
+Known cost components: annual_bill, economic_burden, residual_share, residual_share_epmc.
+Metrics not present in the CAIRO CSV are logged and omitted from the output.
+
+The ``baseline_elec_*`` columns are the annual electric bill components of the
+segment named by the pipeline YAML's ``bill_change_baseline``, read from the
+master **bills** tables.  Build those first (``build_master_bills_prefect.py``).
+
+Identities (per metric m in whichever metrics are present):
+    BAT_m_total = BAT_m_delivery + BAT_m_supply
+
+Identities (per component c):
+    c_total = c_delivery + c_supply
+    annual_bill_total ≈ economic_burden_total + residual_share_total + BAT_percustomer_total
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import cast
+
+import polars as pl
+
+from rate_design.hp_rates.pipeline_config import PipelineConfig, load_pipeline_config
+from utils.file_io import get_aws_storage_options
+from utils.post.baseline_bills import (
+    BASELINE_COLS,
+    baseline_ref_root,
+    load_baseline_reference_annual,
+)
+from utils.post.io import BLDG_ID, scan
+from utils.post.master_metadata import UTILITY_COLS, heating_type_v2, load_metadata
+from utils.post.pipeline_runs import (
+    RunPair,
+    baseline_segment,
+    batch_dir,
+    build_order,
+    expected_segments,
+    find_run_pairs,
+    pipeline_yaml_path,
+    s3_uri,
+    upgrade_for_stage,
+)
+
+BAT_CSV = "cross_subsidization/cross_subsidization_BAT_values.csv"
+
+BAT_METRICS_KNOWN = ["BAT_vol", "BAT_peak", "BAT_percustomer", "BAT_epmc"]
+
+# CAIRO source columns → short output names for the cost-allocation components.
+# These follow the same delivery/supply/total decomposition as BAT metrics.
+# At runtime, we filter to whichever columns are actually present in the CSV.
+COST_COMPONENTS_SRC_KNOWN = {
+    "Annual": "annual_bill",
+    "customer_level_economic_burden": "economic_burden",
+    "customer_level_residual_share_percustomer": "residual_share",
+    "customer_level_residual_share_epmc": "residual_share_epmc",
+}
+
+META_COLS = [
+    BLDG_ID,
+    *UTILITY_COLS,
+    "postprocess_group.has_hp",
+    "postprocess_group.heating_type",
+    "heats_with_electricity",
+    "heats_with_natgas",
+    "heats_with_oil",
+    "heats_with_propane",
+]
+
+META_OUTPUT_COLS = [
+    BLDG_ID,
+    *UTILITY_COLS,
+    "upgrade",
+    "postprocess_group.has_hp",
+    "postprocess_group.heating_type",
+    "postprocess_group.heating_type_v2",
+    "heats_with_electricity",
+    "heats_with_natgas",
+    "heats_with_oil",
+    "heats_with_propane",
+    "weight",
+]
+
+FLOAT_TOL = 1e-4
+
+
+def _build_output_cols(bat_metrics: list[str], cost_components: list[str]) -> list[str]:
+    """Build the output column list from detected metrics and cost components."""
+    cols = list(META_OUTPUT_COLS)
+    for m in bat_metrics:
+        cols.extend(f"{m}_{c}" for c in ("delivery", "supply", "total"))
+    for c in cost_components:
+        cols.extend(f"{c}_{s}" for s in ("delivery", "supply", "total"))
+    return cols
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+_t0 = 0.0
+
+
+def _log(msg: str) -> float:
+    elapsed = time.monotonic() - _t0
+    mm, ss = divmod(int(elapsed), 60)
+    print(f"[{mm:02d}:{ss:02d}] {msg}", file=sys.stderr, flush=True)
+    return time.monotonic()
+
+
+def _log_done(label: str, start: float, detail: str = "") -> None:
+    dt = time.monotonic() - start
+    suffix = f" ({detail})" if detail else ""
+    _log(f"{label}... done ({dt:.1f}s{suffix})")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_utilities(state: str) -> list[str]:
+    """Read UTILITIES from state.env."""
+    repo_root = Path(__file__).resolve().parents[2]
+    env_file = repo_root / "rate_design" / "hp_rates" / state / "state.env"
+    for line in env_file.read_text().splitlines():
+        line = line.strip()
+        if line.startswith("UTILITIES="):
+            return line.split("=", 1)[1].split(",")
+    raise ValueError(f"UTILITIES not found in {env_file}")
+
+
+def _assert_building_match(
+    name_a: str,
+    ids_a: set[int],
+    name_b: str,
+    ids_b: set[int],
+    utility: str,
+) -> None:
+    if ids_a != ids_b:
+        only_a = ids_a - ids_b
+        only_b = ids_b - ids_a
+        examples_a = sorted(only_a)[:10]
+        examples_b = sorted(only_b)[:10]
+        raise AssertionError(
+            f"[{utility}] Building mismatch between {name_a} ({len(ids_a)}) and "
+            f"{name_b} ({len(ids_b)}). "
+            f"Only in {name_a}: {examples_a}{'...' if len(only_a) > 10 else ''}. "
+            f"Only in {name_b}: {examples_b}{'...' if len(only_b) > 10 else ''}."
+        )
+
+
+def _assert_rows_per_building(
+    df: pl.DataFrame, expected: int, label: str, utility: str
+) -> None:
+    counts = df.group_by(BLDG_ID).agg(pl.len().alias("n"))
+    bad = counts.filter(pl.col("n") != expected)
+    if not bad.is_empty():
+        examples = bad.head(5).to_dicts()
+        raise AssertionError(
+            f"[{utility}] {label}: expected {expected} rows per building, "
+            f"but found exceptions: {examples}"
+        )
+
+
+def _assert_bat_identity(
+    df: pl.DataFrame, metric: str, tol: float, utility: str
+) -> None:
+    """Assert BAT_m_total == BAT_m_delivery + BAT_m_supply."""
+    total_col = f"{metric}_total"
+    delivery_col = f"{metric}_delivery"
+    supply_col = f"{metric}_supply"
+    diff = (pl.col(total_col) - pl.col(delivery_col) - pl.col(supply_col)).abs()
+    violations = df.filter(diff > tol)
+    if not violations.is_empty():
+        n = violations.height
+        max_diff = cast(float, violations.select(diff.alias("d"))["d"].max())
+        example = (
+            violations.head(3)
+            .select(BLDG_ID, total_col, delivery_col, supply_col)
+            .to_dicts()
+        )
+        raise AssertionError(
+            f"[{utility}] Identity violation: {total_col} != "
+            f"{delivery_col} + {supply_col}. "
+            f"{n} rows exceed tolerance {tol}, max diff={max_diff:.6f}. "
+            f"Examples: {example}"
+        )
+
+
+def _assert_bill_decomposition(df: pl.DataFrame, tol: float, utility: str) -> None:
+    """Assert annual_bill_total ≈ economic_burden_total + residual_share_total + BAT_percustomer_total."""
+    diff = (
+        pl.col("annual_bill_total")
+        - pl.col("economic_burden_total")
+        - pl.col("residual_share_total")
+        - pl.col("BAT_percustomer_total")
+    ).abs()
+    violations = df.filter(diff > tol)
+    if not violations.is_empty():
+        n = violations.height
+        max_diff = cast(float, violations.select(diff.alias("d"))["d"].max())
+        example = (
+            violations.head(3)
+            .select(
+                BLDG_ID,
+                "annual_bill_total",
+                "economic_burden_total",
+                "residual_share_total",
+                "BAT_percustomer_total",
+            )
+            .to_dicts()
+        )
+        raise AssertionError(
+            f"[{utility}] Bill decomposition violation: "
+            f"annual_bill_total != economic_burden_total + residual_share_total "
+            f"+ BAT_percustomer_total. "
+            f"{n} rows exceed tolerance {tol}, max diff={max_diff:.6f}. "
+            f"Examples: {example}"
+        )
+
+
+def _assert_no_nulls(df: pl.DataFrame, cols: list[str], utility: str) -> None:
+    for c in cols:
+        n_null = df[c].null_count()
+        if n_null > 0:
+            raise AssertionError(f"[{utility}] Column '{c}' has {n_null} null values.")
+
+
+# ---------------------------------------------------------------------------
+# Batch resolution
+# ---------------------------------------------------------------------------
+
+
+def _load_configs(state: str, utilities: list[str]) -> dict[str, PipelineConfig]:
+    """Load one pipeline YAML per utility, resolved by naming convention."""
+    configs: dict[str, PipelineConfig] = {}
+    for utility in utilities:
+        yaml_path = pipeline_yaml_path(state, utility)
+        config = load_pipeline_config(yaml_path)
+        if config.utility != utility or config.state != state:
+            raise ValueError(
+                f"{yaml_path} declares state={config.state}/utility={config.utility}, "
+                f"expected {state}/{utility}"
+            )
+        configs[utility] = config
+    return configs
+
+
+def _resolve_baseline(
+    state: str, configs: dict[str, PipelineConfig]
+) -> tuple[str, str]:
+    """The baseline segment and its upgrade, which every utility must agree on."""
+    baselines: dict[str, tuple[str, str]] = {}
+    for utility, config in configs.items():
+        segment = baseline_segment(config, pipeline_yaml_path(state, utility))
+        assert config.bill_change_baseline is not None  # baseline_segment checked it
+        upgrade = upgrade_for_stage(config, config.bill_change_baseline.stage)
+        baselines[utility] = (segment, upgrade)
+
+    if len(set(baselines.values())) > 1:
+        raise ValueError(
+            f"Utilities in this batch declare different bill_change_baseline "
+            f"segments or upgrades ({baselines}); one master table cannot mix "
+            f"baselines."
+        )
+    return next(iter(baselines.values()))
+
+
+def _resolve_run_pairs(
+    configs: dict[str, PipelineConfig],
+    batch: str,
+    *,
+    scenarios: list[str] | None,
+) -> dict[str, dict[str, RunPair]]:
+    """Per utility, the run pair for each segment that completed in the batch."""
+    pairs: dict[str, dict[str, RunPair]] = {}
+    for utility, config in configs.items():
+        found = find_run_pairs(config, batch, scenarios=scenarios)
+        skipped = [
+            segment
+            for segment in expected_segments(config, scenarios=scenarios)
+            if segment not in found
+        ]
+        _log(f"  {utility}: {len(found)} segment(s) found: {list(found)}")
+        if skipped:
+            _log(f"  {utility}: skipping {len(skipped)} segment(s) not run: {skipped}")
+        if not found:
+            raise FileNotFoundError(
+                f"No completed runs for {utility} in batch {batch}: no index "
+                f"files under {batch_dir(config, batch)}/.runs/"
+            )
+        pairs[utility] = found
+    return pairs
+
+
+def _ordered_segments(pairs: dict[str, dict[str, RunPair]], baseline: str) -> list[str]:
+    """Every segment present for at least one utility, baseline first."""
+    ordered: list[str] = []
+    for per_utility in pairs.values():
+        for segment in per_utility:
+            if segment not in ordered:
+                ordered.append(segment)
+    return build_order(ordered, baseline)
+
+
+# ---------------------------------------------------------------------------
+# Per-utility processing
+# ---------------------------------------------------------------------------
+
+
+def _process_utility(
+    utility: str,
+    run: RunPair,
+    metadata_for_utility: pl.DataFrame,
+    *,
+    state_lower: str,
+    batch: str,
+    baseline: str,
+    baseline_upgrade: str,
+    storage_options: dict[str, str] | None,
+) -> pl.DataFrame:
+    """Build the master BAT table fragment for a single utility and segment."""
+    meta_bldg_ids = set(metadata_for_utility[BLDG_ID].to_list())
+    n_bldgs = len(meta_bldg_ids)
+
+    _log(f"  delivery={run.dir_delivery.rstrip('/').split('/')[-1]}")
+    _log(f"  supply={run.dir_supply.rstrip('/').split('/')[-1]}")
+
+    # --- Read BAT CSVs ---
+    t = _log("  Reading BAT values (delivery run)...")
+    bat_delivery_df = cast(
+        pl.DataFrame, scan(f"{run.dir_delivery}/{BAT_CSV}").collect()
+    )
+    _log_done("  Reading BAT delivery", t, f"{bat_delivery_df.height} rows")
+
+    t = _log("  Reading BAT values (supply run)...")
+    bat_supply_df = cast(pl.DataFrame, scan(f"{run.dir_supply}/{BAT_CSV}").collect())
+    _log_done("  Reading BAT supply", t, f"{bat_supply_df.height} rows")
+
+    # --- Validate building IDs ---
+    delivery_ids = set(bat_delivery_df[BLDG_ID].unique().to_list())
+    supply_ids = set(bat_supply_df[BLDG_ID].unique().to_list())
+    _assert_building_match(
+        "bat_delivery", delivery_ids, "bat_supply", supply_ids, utility
+    )
+    _assert_building_match(
+        "bat_delivery", delivery_ids, "metadata", meta_bldg_ids, utility
+    )
+    _assert_rows_per_building(bat_delivery_df, 1, "bat_delivery", utility)
+    _assert_rows_per_building(bat_supply_df, 1, "bat_supply", utility)
+
+    # --- Validate weights match between runs ---
+    weight_check = bat_delivery_df.select(BLDG_ID, pl.col("weight").alias("w_d")).join(
+        bat_supply_df.select(BLDG_ID, pl.col("weight").alias("w_s")),
+        on=BLDG_ID,
+        how="inner",
+    )
+    weight_diff = (weight_check["w_d"] - weight_check["w_s"]).abs()
+    n_weight_diff = (weight_diff > 1e-9).sum()
+    if n_weight_diff > 0:
+        raise AssertionError(
+            f"[{utility}] Weights differ between delivery and supply BAT CSVs: "
+            f"{n_weight_diff} rows, max diff={weight_diff.max()}"
+        )
+
+    # --- Detect available BAT metrics and cost components ---
+    delivery_cols = set(bat_delivery_df.columns)
+    bat_metrics = [m for m in BAT_METRICS_KNOWN if m in delivery_cols]
+    missing_bat = set(BAT_METRICS_KNOWN) - set(bat_metrics)
+    if missing_bat:
+        _log(
+            f"  [{utility}] BAT metrics not in CAIRO output (skipping): "
+            f"{sorted(missing_bat)}"
+        )
+
+    cost_components_src = {
+        k: v for k, v in COST_COMPONENTS_SRC_KNOWN.items() if k in delivery_cols
+    }
+    missing_cost = set(COST_COMPONENTS_SRC_KNOWN) - set(cost_components_src)
+    if missing_cost:
+        _log(
+            f"  [{utility}] Cost components not in CAIRO output (skipping): "
+            f"{sorted(missing_cost)}"
+        )
+    cost_components = list(cost_components_src.values())
+
+    # --- Validate no nulls in source columns ---
+    _assert_no_nulls(bat_delivery_df, bat_metrics, utility)
+    _assert_no_nulls(bat_supply_df, bat_metrics, utility)
+    _assert_no_nulls(bat_delivery_df, list(cost_components_src.keys()), utility)
+    _assert_no_nulls(bat_supply_df, list(cost_components_src.keys()), utility)
+
+    # --- Join delivery and supply, compute decomposition ---
+    t = _log("  Computing BAT decomposition (delivery / supply / total)...")
+    delivery_select = (
+        [BLDG_ID, "weight"]
+        + [pl.col(m).alias(f"{m}_delivery") for m in bat_metrics]
+        + [
+            pl.col(src).alias(f"{short}_delivery")
+            for src, short in cost_components_src.items()
+        ]
+    )
+    supply_select = (
+        [BLDG_ID]
+        + [pl.col(m).alias(f"{m}_total") for m in bat_metrics]
+        + [
+            pl.col(src).alias(f"{short}_total")
+            for src, short in cost_components_src.items()
+        ]
+    )
+    bat = (
+        bat_delivery_df.select(delivery_select)
+        .join(
+            bat_supply_df.select(supply_select),
+            on=BLDG_ID,
+            how="inner",
+        )
+        .with_columns(
+            [
+                (pl.col(f"{m}_total") - pl.col(f"{m}_delivery")).alias(f"{m}_supply")
+                for m in bat_metrics
+            ]
+            + [
+                (pl.col(f"{c}_total") - pl.col(f"{c}_delivery")).alias(f"{c}_supply")
+                for c in cost_components
+            ]
+        )
+    )
+    _log_done("  BAT decomposition", t, f"{bat.height} rows")
+
+    # --- Join with metadata ---
+    t = _log("  Joining with metadata...")
+    output_cols = _build_output_cols(bat_metrics, cost_components)
+    joined_core = (
+        bat.join(
+            metadata_for_utility.select(META_COLS),
+            on=BLDG_ID,
+            how="inner",
+        )
+        .with_columns(
+            pl.lit(int(run.upgrade)).alias("upgrade"),
+            heating_type_v2(),
+        )
+        .select(output_cols)
+    )
+    ref = load_baseline_reference_annual(
+        state_lower=state_lower,
+        output_batch=batch,
+        segment=baseline,
+        utility=utility,
+        expected_upgrade=baseline_upgrade,
+        storage_options=storage_options,
+    )
+    joined = joined_core.join(ref, on=BLDG_ID, how="left")
+    n_null = int(joined["baseline_elec_delivery_bill"].null_count())
+    if n_null > 0:
+        root = baseline_ref_root(
+            state_lower=state_lower, output_batch=batch, segment=baseline
+        )
+        raise FileNotFoundError(
+            f"[{utility}] Could not join baseline columns from {baseline!r} "
+            f"({n_null} null rows). Build master comb bills for the baseline "
+            f"segment first: {root}"
+        )
+    _log_done("  Joining with metadata", t, f"{joined.height} rows")
+
+    if joined.height != n_bldgs:
+        raise AssertionError(
+            f"[{utility}] Expected {n_bldgs} rows (1 per building), got {joined.height}"
+        )
+
+    # --- Validate identities and nulls ---
+    for m in bat_metrics:
+        _assert_bat_identity(joined, m, FLOAT_TOL, utility)
+    for c in cost_components:
+        _assert_bat_identity(joined, c, FLOAT_TOL, utility)
+    _assert_bill_decomposition(joined, FLOAT_TOL, utility)
+
+    bat_output_cols = [
+        f"{m}_{component}"
+        for m in bat_metrics
+        for component in ("delivery", "supply", "total")
+    ]
+    cost_output_cols = [
+        f"{c}_{component}"
+        for c in cost_components
+        for component in ("delivery", "supply", "total")
+    ]
+    _assert_no_nulls(
+        joined,
+        ["weight"] + bat_output_cols + cost_output_cols + BASELINE_COLS,
+        utility,
+    )
+
+    return joined
+
+
+def _write_parquet_dir(df: pl.DataFrame, output_s3: str) -> None:
+    """Write one parquet file to an S3 prefix."""
+    tmp_dir = Path(tempfile.mkdtemp(prefix="master_bat_"))
+    try:
+        df.write_parquet(tmp_dir / "data.parquet")
+        subprocess.run(
+            ["aws", "s3", "sync", str(tmp_dir), output_s3],
+            check=True,
+            capture_output=True,
+        )
+    finally:
+        import shutil
+
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def _write_hive_partitioned(
+    df: pl.DataFrame, output_s3: str, partition_col: str
+) -> None:
+    """Write a Hive-partitioned dataset (one parquet per partition value) to S3."""
+    tmp_dir = Path(tempfile.mkdtemp(prefix="master_bat_all_"))
+    try:
+        for value, part_df in df.group_by(partition_col):
+            part_dir = tmp_dir / f"{partition_col}={value[0]}"
+            part_dir.mkdir(parents=True, exist_ok=True)
+            part_df.drop(partition_col).write_parquet(part_dir / "data.parquet")
+        subprocess.run(
+            ["aws", "s3", "sync", str(tmp_dir), output_s3],
+            check=True,
+            capture_output=True,
+        )
+    finally:
+        import shutil
+
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build master BAT tables for every scenario/stage in a "
+        "Prefect pipeline batch.",
+    )
+    parser.add_argument("--state", required=True, help="State code (e.g. md)")
+    parser.add_argument(
+        "--batch",
+        required=True,
+        help="Batch name as passed to run_pipeline.py (e.g. md_20260803_a).",
+    )
+    parser.add_argument(
+        "--utilities",
+        default=None,
+        help="Comma-separated utilities to process (default: all from state.env). "
+        "Each needs a pipeline YAML at "
+        "{state}/config/scenarios/pipeline_{utility}.yaml.",
+    )
+    parser.add_argument(
+        "--scenarios",
+        nargs="*",
+        default=None,
+        help="Optional scenario names to process (space-separated). Omit for all.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    global _t0
+    _t0 = time.monotonic()
+    args = _parse_args()
+
+    state = args.state.lower()
+    state_upper = state.upper()
+    utilities = args.utilities.split(",") if args.utilities else _read_utilities(state)
+    storage_options = get_aws_storage_options()
+
+    _log(
+        f"Building master BAT: state={state_upper}, batch={args.batch}, "
+        f"utilities={utilities}"
+    )
+
+    # --- Resolve the batch: configs, baseline, and completed run pairs ---
+    configs = _load_configs(state, utilities)
+    baseline, baseline_upgrade = _resolve_baseline(state, configs)
+    run_pairs = _resolve_run_pairs(configs, args.batch, scenarios=args.scenarios)
+    segments = _ordered_segments(run_pairs, baseline)
+    _log(f"Baseline segment: {baseline} (upgrade {baseline_upgrade})")
+    _log(f"Segments: {segments}")
+
+    # --- Load metadata (one read per distinct ResStock release) ---
+    metadata_by_base: dict[str, pl.DataFrame] = {}
+    for utility, config in configs.items():
+        base = config.run_defaults.resstock_base.rstrip("/")
+        if base in metadata_by_base:
+            continue
+        t = _log(f"Loading metadata from {base}...")
+        metadata_by_base[base] = load_metadata(base, state_upper)
+        _log_done("Loading metadata", t, f"{metadata_by_base[base].height} rows")
+
+    bldgs_per_utility: dict[str, int] = {}
+    for utility, config in configs.items():
+        metadata = metadata_by_base[config.run_defaults.resstock_base.rstrip("/")]
+        n = metadata.filter(pl.col("sb.electric_utility") == utility)[
+            BLDG_ID
+        ].n_unique()
+        bldgs_per_utility[utility] = n
+        _log(f"  {utility}: {n} buildings")
+
+    output_base_s3 = s3_uri(next(iter(configs.values())).output_base).rstrip("/")
+
+    # --- One master table per segment ---
+    for seg_i, segment in enumerate(segments, 1):
+        seg_utilities = [u for u in utilities if segment in run_pairs.get(u, {})]
+        _log(
+            f"=== Segment {seg_i}/{len(segments)}: {segment} "
+            f"({len(seg_utilities)} utility/ies: {seg_utilities}) ==="
+        )
+
+        all_dfs: list[pl.DataFrame] = []
+        for i, utility in enumerate(seg_utilities, 1):
+            config = configs[utility]
+            base = config.run_defaults.resstock_base.rstrip("/")
+            _log(f"Processing utility {i}/{len(seg_utilities)}: {utility}")
+
+            df = _process_utility(
+                utility=utility,
+                run=run_pairs[utility][segment],
+                metadata_for_utility=metadata_by_base[base].filter(
+                    pl.col("sb.electric_utility") == utility
+                ),
+                state_lower=state,
+                batch=args.batch,
+                baseline=baseline,
+                baseline_upgrade=baseline_upgrade,
+                storage_options=storage_options,
+            )
+
+            per_util_output_s3 = (
+                f"{output_base_s3}/{state}/{utility}/{args.batch}/{segment}/"
+                f"cross_subsidization_BAT_values/"
+            )
+            t_util = _log(f"  Writing per-utility output to {per_util_output_s3}...")
+            _write_parquet_dir(df, per_util_output_s3)
+            _log_done(f"  Writing per-utility {utility}", t_util)
+
+            all_dfs.append(df)
+
+        # --- Concatenate ---
+        t = _log("Concatenating all utilities...")
+        master = pl.concat(all_dfs)
+        _log_done(
+            "Concatenating",
+            t,
+            f"{master.height} rows, {master[BLDG_ID].n_unique()} buildings",
+        )
+
+        # --- Final validation ---
+        t = _log("Validating final table...")
+        final_bldg_count = master[BLDG_ID].n_unique()
+        expected_bldgs = sum(bldgs_per_utility[u] for u in seg_utilities)
+        if final_bldg_count != expected_bldgs:
+            raise AssertionError(
+                f"Final building count {final_bldg_count} != expected "
+                f"{expected_bldgs} (across {len(seg_utilities)} utilities)"
+            )
+
+        per_util_check = master.group_by("sb.electric_utility").agg(
+            pl.col(BLDG_ID).n_unique().alias("n_bldgs")
+        )
+        for row in per_util_check.iter_rows(named=True):
+            u = row["sb.electric_utility"]
+            actual = row["n_bldgs"]
+            expected = bldgs_per_utility.get(u, -1)
+            if actual != expected:
+                raise AssertionError(
+                    f"Utility {u}: expected {expected} buildings, got {actual}"
+                )
+
+        master_cols = set(master.columns)
+        final_bat_metrics = [
+            m for m in BAT_METRICS_KNOWN if f"{m}_delivery" in master_cols
+        ]
+        final_cost_components = [
+            v
+            for v in COST_COMPONENTS_SRC_KNOWN.values()
+            if f"{v}_delivery" in master_cols
+        ]
+        for m in final_bat_metrics:
+            _assert_bat_identity(master, m, FLOAT_TOL, "ALL")
+        for c in final_cost_components:
+            _assert_bat_identity(master, c, FLOAT_TOL, "ALL")
+        _assert_bill_decomposition(master, FLOAT_TOL, "ALL")
+        _log_done("Validation", t)
+
+        # --- Write output (Hive-partitioned parquet) ---
+        output_s3 = (
+            f"{output_base_s3}/{state}/all_utilities/{args.batch}/{segment}/"
+            f"cross_subsidization_BAT_values/"
+        )
+        t = _log(f"Writing to {output_s3}...")
+        _write_hive_partitioned(master, output_s3, "sb.electric_utility")
+        _log_done("Writing", t)
+
+    total_elapsed = time.monotonic() - _t0
+    mm, ss = divmod(int(total_elapsed), 60)
+    _log(f"Done: {len(segments)} segment(s) (total: {mm}m {ss}s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/post/build_master_bills_prefect.py
+++ b/utils/post/build_master_bills_prefect.py
@@ -1,0 +1,1120 @@
+"""Build master bills tables for a Prefect pipeline batch.
+
+Prefect-native counterpart of ``build_master_bills.py``.  Runs are discovered
+from each utility's pipeline YAML plus the batch's ``.runs/`` index instead of
+numeric run numbers, and one invocation covers every ``(scenario, stage)`` in
+the batch — each becoming its own master table.
+
+Reads CAIRO bill outputs, ResStock metadata, tariff fixed charges, and EIA fuel
+prices to produce a Hive-partitioned parquet dataset (partitioned by
+sb.electric_utility) with fully decomposed energy bills: electric (fixed +
+volumetric delivery + supply), gas, oil, and propane.
+
+Outputs, one pair per ``{scenario}_{stage}`` segment:
+    per-utility:   {output_base}/{state}/{utility}/{batch}/{segment}/comb_bills_year_target/
+    all utilities: {output_base}/{state}/all_utilities/{batch}/{segment}/comb_bills_year_target/
+
+Output schema (13 rows per building: Jan..Dec + Annual):
+    bldg_id, sb.electric_utility, sb.gas_utility, upgrade, postprocess_group.has_hp,
+    postprocess_group.heating_type, postprocess_group.heating_type_v2,
+    heats_with_electricity, heats_with_natgas,
+    heats_with_oil, heats_with_propane, in.representative_income,
+    in.hvac_cooling_partial_space_conditioning, month, weight,
+    elec_fixed_charge, elec_delivery_bill, elec_supply_bill, elec_total_bill,
+    baseline_elec_fixed_charge, baseline_elec_delivery_bill, baseline_elec_supply_bill,
+    gas_fixed_charge, gas_volumetric_bill, gas_total_bill,
+    propane_total_bill, oil_total_bill, energy_total_bill
+
+The ``baseline_elec_*`` columns are the electric bill components of the segment
+named by the pipeline YAML's ``bill_change_baseline``, repeated on every other
+segment for the same ``(bldg_id, month)``.  On the baseline segment itself they
+equal the row's own ``elec_*`` values.  The baseline segment is therefore built
+first.
+
+Identities:
+    elec_total_bill = elec_fixed_charge + elec_delivery_bill + elec_supply_bill
+    gas_total_bill = gas_fixed_charge + gas_volumetric_bill
+    energy_total_bill = elec_total_bill + gas_total_bill + propane_total_bill + oil_total_bill
+
+When ``--calculate-lmi`` is passed for NY or RI, the script also appends the LMI
+discount columns before writing each final output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import cast
+
+import polars as pl
+
+from rate_design.hp_rates.pipeline_config import PipelineConfig, load_pipeline_config
+from utils.file_io import get_aws_storage_options
+from utils.post import apply_ny_lmi_to_master_bills as ny_lmi_master_bills
+from utils.post.apply_ny_lmi_to_master_bills import apply_ny_lmi_to_master
+from utils.post.apply_ri_lmi_discounts_to_bills import apply_ri_lmi_to_master
+from utils.post.baseline_bills import (
+    BASELINE_COLS,
+    baseline_columns_from_self,
+    baseline_ref_root,
+    load_baseline_reference_monthly,
+)
+from utils.post.delivered_fuel_bills import compute_fuel_bills, load_monthly_fuel_prices
+from utils.post.gas_bills import (
+    build_fixed_charge_table,
+    build_rate_table,
+    compute_gas_bills,
+    load_gas_tariff_map,
+    load_gas_tariffs,
+)
+from utils.post.io import (
+    ANNUAL_MONTH,
+    BILL_LEVEL,
+    BLDG_ID,
+    scan,
+    scan_load_curves_for_utility,
+)
+from utils.post.pipeline_runs import (
+    RunPair,
+    baseline_segment,
+    batch_dir,
+    build_order,
+    expected_segments,
+    find_run_pairs,
+    pipeline_yaml_path,
+    s3_uri,
+    upgrade_for_stage,
+)
+
+ELEC_BILLS_CSV = "bills/elec_bills_year_target.csv"
+
+# Building attributes are read from the baseline upgrade on every segment, so a
+# home's pre-retrofit heating type stays sliceable on calibrated segments (where
+# ResStock marks every building as a heat pump).  The ``upgrade`` column is set
+# from the segment's own stage, not from here.
+METADATA_UPGRADE = "00"
+
+ATTR_COLS = [
+    "postprocess_group.has_hp",
+    "postprocess_group.heating_type",
+    "heats_with_electricity",
+    "heats_with_natgas",
+    "heats_with_oil",
+    "heats_with_propane",
+    "in.representative_income",
+    "in.hvac_cooling_partial_space_conditioning",
+]
+
+META_COLS = [BLDG_ID, "sb.electric_utility", "sb.gas_utility", *ATTR_COLS]
+
+OUTPUT_COLS = [
+    BLDG_ID,
+    "sb.electric_utility",
+    "sb.gas_utility",
+    "upgrade",
+    "postprocess_group.has_hp",
+    "postprocess_group.heating_type",
+    "postprocess_group.heating_type_v2",
+    "heats_with_electricity",
+    "heats_with_natgas",
+    "heats_with_oil",
+    "heats_with_propane",
+    "in.representative_income",
+    "in.hvac_cooling_partial_space_conditioning",
+    "month",
+    "weight",
+    "elec_fixed_charge",
+    "elec_delivery_bill",
+    "elec_supply_bill",
+    "elec_total_bill",
+    *BASELINE_COLS,
+    "gas_fixed_charge",
+    "gas_volumetric_bill",
+    "gas_total_bill",
+    "propane_total_bill",
+    "oil_total_bill",
+    "energy_total_bill",
+]
+
+FLOAT_TOL = 1e-4
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+_t0 = 0.0
+
+
+def _log(msg: str) -> float:
+    elapsed = time.monotonic() - _t0
+    mm, ss = divmod(int(elapsed), 60)
+    print(f"[{mm:02d}:{ss:02d}] {msg}", file=sys.stderr, flush=True)
+    return time.monotonic()
+
+
+def _log_done(label: str, start: float, detail: str = "") -> None:
+    dt = time.monotonic() - start
+    suffix = f" ({detail})" if detail else ""
+    _log(f"{label}... done ({dt:.1f}s{suffix})")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_utilities(state: str) -> list[str]:
+    """Read UTILITIES from state.env."""
+    repo_root = Path(__file__).resolve().parents[2]
+    env_file = repo_root / "rate_design" / "hp_rates" / state / "state.env"
+    for line in env_file.read_text().splitlines():
+        line = line.strip()
+        if line.startswith("UTILITIES="):
+            return line.split("=", 1)[1].split(",")
+    raise ValueError(f"UTILITIES not found in {env_file}")
+
+
+def _load_metadata(path_resstock_base: str, state_upper: str) -> pl.DataFrame:
+    """Utility assignment joined to baseline building attributes.
+
+    ``utility_assignment.parquet`` carries only the electric/gas utility mapping
+    in newer ResStock releases, so attributes come from the baseline upgrade's
+    ``metadata-sb.parquet``.  Older releases have those attributes on the
+    assignment table too; they are ignored in favour of one code path.
+    """
+    base = path_resstock_base.rstrip("/")
+    assignment = pl.scan_parquet(
+        f"{base}/metadata_utility/state={state_upper}/utility_assignment.parquet"
+    ).select(BLDG_ID, "sb.electric_utility", "sb.gas_utility")
+    attributes = pl.scan_parquet(
+        f"{base}/metadata/state={state_upper}/upgrade={METADATA_UPGRADE}/metadata-sb.parquet"
+    ).select(BLDG_ID, *ATTR_COLS)
+    return cast(
+        pl.DataFrame,
+        assignment.join(attributes, on=BLDG_ID, how="inner").collect(),
+    )
+
+
+def _s3_get_json(uri: str) -> dict:
+    """Fetch and parse a JSON file from S3 via boto3."""
+    import boto3
+
+    without_scheme = uri[len("s3://") :]
+    bucket, _, key = without_scheme.partition("/")
+    body = boto3.client("s3").get_object(Bucket=bucket, Key=key)["Body"].read()
+    return json.loads(body)
+
+
+def _extract_fixed_charges_from_tariff_config(
+    payload: dict,
+) -> dict[str, float]:
+    """Extract ``{tariff_key: monthly_fixed_charge}`` from ``tariff_final_config.json``.
+
+    Handles both CAIRO format (top-level keys → dicts with
+    ``ur_monthly_fixed_charge``) and URDB format (``items`` list with
+    ``fixedchargefirstmeter``).
+    """
+    if "items" in payload:
+        items = payload["items"]
+        if items and isinstance(items[0], dict):
+            label = items[0].get("label") or items[0].get("name") or "calibrated"
+            fc = items[0].get("fixedchargefirstmeter")
+            if fc is None:
+                raise ValueError(
+                    "URDB tariff_final_config has 'items' but no fixedchargefirstmeter"
+                )
+            return {str(label): float(fc)}
+        raise ValueError("tariff_final_config has 'items' but it is empty")
+
+    result: dict[str, float] = {}
+    for key, value in payload.items():
+        if isinstance(value, dict):
+            fc = value.get("ur_monthly_fixed_charge")
+            if fc is None:
+                raise ValueError(
+                    f"Tariff key '{key}' in tariff_final_config.json "
+                    "has no ur_monthly_fixed_charge"
+                )
+            result[key] = float(fc)
+    if not result:
+        raise ValueError(
+            "No tariff keys found in tariff_final_config.json "
+            "(expected top-level keys with dict values or URDB 'items')"
+        )
+    return result
+
+
+def _read_fixed_charges(dir_delivery: str, bldg_ids: set[int]) -> pl.DataFrame:
+    """Read per-building monthly fixed charges from the delivery run directory.
+
+    Returns a DataFrame with columns ``(bldg_id, elec_fixed_charge_monthly)``.
+
+    1. Reads ``tariff_final_config.json`` from *dir_delivery*.
+    2. If all tariff keys share the same fixed charge, broadcasts it.
+    3. If they differ, reads the tariff map CSV named in the run's
+       ``scenario_settings.json`` and joins to get per-building charges.
+    """
+    payload = _s3_get_json(f"{dir_delivery.rstrip('/')}/tariff_final_config.json")
+    fc_by_key = _extract_fixed_charges_from_tariff_config(payload)
+
+    unique_fcs = set(fc_by_key.values())
+    if len(unique_fcs) == 1:
+        fc_value = next(iter(unique_fcs))
+        return pl.DataFrame(
+            {BLDG_ID: sorted(bldg_ids), "elec_fixed_charge_monthly": fc_value}
+        ).cast({BLDG_ID: pl.Int64, "elec_fixed_charge_monthly": pl.Float64})
+
+    tariff_map_path = _resolve_tariff_map_path(dir_delivery)
+    tariff_map = pl.read_csv(tariff_map_path, schema_overrides={BLDG_ID: pl.Int64})
+
+    fc_lookup = pl.DataFrame(
+        {
+            "tariff_key": list(fc_by_key.keys()),
+            "elec_fixed_charge_monthly": list(fc_by_key.values()),
+        }
+    )
+    result = tariff_map.join(fc_lookup, on="tariff_key", how="inner").select(
+        BLDG_ID, "elec_fixed_charge_monthly"
+    )
+
+    result_ids = set(result[BLDG_ID].to_list())
+    missing = bldg_ids - result_ids
+    if missing:
+        examples = sorted(missing)[:10]
+        raise ValueError(
+            f"Tariff map does not cover {len(missing)} buildings. "
+            f"Examples: {examples}. "
+            f"Tariff keys in config: {sorted(fc_by_key.keys())}. "
+            f"Tariff map: {tariff_map_path}"
+        )
+    return result
+
+
+def _resolve_tariff_map_path(dir_delivery: str) -> str:
+    """Read the electric tariff map CSV path from the run's ``scenario_settings.json``."""
+    settings_uri = f"{dir_delivery.rstrip('/')}/scenario_settings.json"
+    try:
+        settings = _s3_get_json(settings_uri)
+    except Exception as exc:
+        raise FileNotFoundError(
+            f"Multiple tariff keys with different fixed charges but no "
+            f"scenario_settings.json at {settings_uri} to name the tariff map."
+        ) from exc
+
+    path = settings.get("path_tariff_maps_electric")
+    if not path:
+        raise ValueError(
+            f"scenario_settings.json at {settings_uri} has no "
+            "path_tariff_maps_electric field"
+        )
+    return str(path)
+
+
+def _assert_building_match(
+    name_a: str,
+    ids_a: set[int],
+    name_b: str,
+    ids_b: set[int],
+    utility: str,
+) -> None:
+    if ids_a != ids_b:
+        only_a = ids_a - ids_b
+        only_b = ids_b - ids_a
+        examples_a = sorted(only_a)[:10]
+        examples_b = sorted(only_b)[:10]
+        raise AssertionError(
+            f"[{utility}] Building mismatch between {name_a} ({len(ids_a)}) and "
+            f"{name_b} ({len(ids_b)}). "
+            f"Only in {name_a}: {examples_a}{'...' if len(only_a) > 10 else ''}. "
+            f"Only in {name_b}: {examples_b}{'...' if len(only_b) > 10 else ''}."
+        )
+
+
+def _assert_rows_per_building(
+    df: pl.DataFrame, expected: int, label: str, utility: str
+) -> None:
+    counts = df.group_by(BLDG_ID).agg(pl.len().alias("n"))
+    bad = counts.filter(pl.col("n") != expected)
+    if not bad.is_empty():
+        examples = bad.head(5).to_dicts()
+        raise AssertionError(
+            f"[{utility}] {label}: expected {expected} rows per building, "
+            f"but found exceptions: {examples}"
+        )
+
+
+def _assert_identity(
+    df: pl.DataFrame, lhs: str, rhs_cols: list[str], tol: float, utility: str
+) -> None:
+    rhs_sum = pl.sum_horizontal(*[pl.col(c) for c in rhs_cols])
+    diff = (pl.col(lhs) - rhs_sum).abs()
+    violations = df.filter(diff > tol)
+    if not violations.is_empty():
+        n = violations.height
+        max_diff = cast(float, violations.select(diff.alias("d"))["d"].max())
+        example = violations.head(3).select(BLDG_ID, "month", lhs, *rhs_cols).to_dicts()
+        raise AssertionError(
+            f"[{utility}] Identity violation: {lhs} != sum({rhs_cols}). "
+            f"{n} rows exceed tolerance {tol}, max diff={max_diff:.6f}. "
+            f"Examples: {example}"
+        )
+
+
+def _assert_no_nulls(df: pl.DataFrame, cols: list[str], utility: str) -> None:
+    for c in cols:
+        n_null = df[c].null_count()
+        if n_null > 0:
+            raise AssertionError(f"[{utility}] Column '{c}' has {n_null} null values.")
+
+
+def _attach_baseline_columns(
+    df: pl.DataFrame,
+    *,
+    state_lower: str,
+    utility: str,
+    batch: str,
+    segment: str,
+    baseline: str,
+    baseline_upgrade: str,
+    storage_options: dict[str, str] | None,
+) -> pl.DataFrame:
+    """Attach the baseline segment's electric bill components to every row."""
+    if segment == baseline:
+        return df.with_columns(baseline_columns_from_self())
+
+    ref = load_baseline_reference_monthly(
+        state_lower=state_lower,
+        output_batch=batch,
+        segment=baseline,
+        utility=utility,
+        expected_upgrade=baseline_upgrade,
+        storage_options=storage_options,
+    )
+    out = df.join(ref, on=[BLDG_ID, "month"], how="left")
+    n_null = int(out["baseline_elec_delivery_bill"].null_count())
+    if n_null > 0:
+        root = baseline_ref_root(
+            state_lower=state_lower, output_batch=batch, segment=baseline
+        )
+        raise FileNotFoundError(
+            f"[{utility}] Could not join baseline columns from {baseline!r} "
+            f"({n_null} null rows). Build master comb bills for the baseline "
+            f"segment first: {root}"
+        )
+    return out
+
+
+def _apply_lmi_discounts_to_master(
+    master: pl.DataFrame,
+    *,
+    state_upper: str,
+    utilities: list[str],
+    upgrade: str,
+    path_resstock_release: str,
+    lmi_fpl_year: int,
+    lmi_cpi_s3_path: str,
+    lmi_participation_rates: list[float],
+    lmi_participation_mode: str,
+    lmi_seed: int,
+    lmi_calculation_type: str,
+) -> pl.DataFrame:
+    """Dispatch LMI discount augmentation to the appropriate state module."""
+    opts = get_aws_storage_options()
+
+    if state_upper == "NY":
+        # Sync elapsed-time logging so NY helper uses this script's start time.
+        ny_lmi_master_bills._t0 = _t0
+        return apply_ny_lmi_to_master(
+            master,
+            utilities=utilities,
+            upgrade=upgrade,
+            path_resstock_release=path_resstock_release,
+            lmi_fpl_year=lmi_fpl_year,
+            lmi_cpi_s3_path=lmi_cpi_s3_path,
+            participation_rates=lmi_participation_rates,
+            participation_mode=lmi_participation_mode,
+            seed=lmi_seed,
+            calculation_type=lmi_calculation_type,
+            opts=opts,
+        )
+
+    if state_upper == "RI":
+        if len(utilities) != 1:
+            raise ValueError(
+                f"RI LMI expects exactly one utility in the run; got {utilities}"
+            )
+        return apply_ri_lmi_to_master(
+            master,
+            utility=utilities[0],
+            state_upper=state_upper,
+            upgrade=upgrade,
+            path_resstock_release=path_resstock_release,
+            lmi_fpl_year=lmi_fpl_year,
+            lmi_cpi_s3_path=lmi_cpi_s3_path,
+            participation_rates=lmi_participation_rates,
+            participation_mode=lmi_participation_mode,
+            seed=lmi_seed,
+            opts=opts,
+        )
+
+    raise ValueError(
+        f"--calculate-lmi is not supported for state {state_upper!r}. "
+        "Supported states: NY, RI."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Batch resolution
+# ---------------------------------------------------------------------------
+
+
+def _load_configs(state: str, utilities: list[str]) -> dict[str, PipelineConfig]:
+    """Load one pipeline YAML per utility, resolved by naming convention."""
+    configs: dict[str, PipelineConfig] = {}
+    for utility in utilities:
+        yaml_path = pipeline_yaml_path(state, utility)
+        config = load_pipeline_config(yaml_path)
+        if config.utility != utility or config.state != state:
+            raise ValueError(
+                f"{yaml_path} declares state={config.state}/utility={config.utility}, "
+                f"expected {state}/{utility}"
+            )
+        configs[utility] = config
+    return configs
+
+
+def _resolve_baseline(
+    state: str, configs: dict[str, PipelineConfig]
+) -> tuple[str, str]:
+    """The baseline segment and its upgrade, which every utility must agree on.
+
+    The upgrade comes from the config rather than from the baseline run, so it
+    is known even when the baseline segment is not part of this invocation.
+    """
+    baselines: dict[str, tuple[str, str]] = {}
+    for utility, config in configs.items():
+        segment = baseline_segment(config, pipeline_yaml_path(state, utility))
+        assert config.bill_change_baseline is not None  # baseline_segment checked it
+        upgrade = upgrade_for_stage(config, config.bill_change_baseline.stage)
+        baselines[utility] = (segment, upgrade)
+
+    if len(set(baselines.values())) > 1:
+        raise ValueError(
+            f"Utilities in this batch declare different bill_change_baseline "
+            f"segments or upgrades ({baselines}); one master table cannot mix "
+            f"baselines."
+        )
+    return next(iter(baselines.values()))
+
+
+def _resolve_run_pairs(
+    configs: dict[str, PipelineConfig],
+    batch: str,
+    *,
+    scenarios: list[str] | None,
+) -> dict[str, dict[str, RunPair]]:
+    """Per utility, the run pair for each segment that completed in the batch."""
+    pairs: dict[str, dict[str, RunPair]] = {}
+    for utility, config in configs.items():
+        found = find_run_pairs(config, batch, scenarios=scenarios)
+        skipped = [
+            segment
+            for segment in expected_segments(config, scenarios=scenarios)
+            if segment not in found
+        ]
+        _log(f"  {utility}: {len(found)} segment(s) found: {list(found)}")
+        if skipped:
+            _log(f"  {utility}: skipping {len(skipped)} segment(s) not run: {skipped}")
+        if not found:
+            raise FileNotFoundError(
+                f"No completed runs for {utility} in batch {batch}: no index "
+                f"files under {batch_dir(config, batch)}/.runs/"
+            )
+        pairs[utility] = found
+    return pairs
+
+
+def _ordered_segments(pairs: dict[str, dict[str, RunPair]], baseline: str) -> list[str]:
+    """Every segment present for at least one utility, baseline first."""
+    ordered: list[str] = []
+    for per_utility in pairs.values():
+        for segment in per_utility:
+            if segment not in ordered:
+                ordered.append(segment)
+    return build_order(ordered, baseline)
+
+
+# ---------------------------------------------------------------------------
+# Per-utility processing
+# ---------------------------------------------------------------------------
+
+
+def _process_utility(
+    utility: str,
+    state: str,
+    run: RunPair,
+    metadata_for_utility: pl.DataFrame,
+    monthly_prices: pl.DataFrame,
+    path_resstock_base: str,
+    gas_rate_table: pl.DataFrame,
+    gas_fixed_charges: pl.DataFrame,
+    *,
+    batch: str,
+    baseline: str,
+    baseline_upgrade: str,
+    storage_options: dict[str, str] | None,
+) -> pl.DataFrame:
+    """Build the master table fragment for a single utility and segment."""
+    meta_bldg_ids = set(metadata_for_utility[BLDG_ID].to_list())
+    n_bldgs = len(meta_bldg_ids)
+    upgrade = run.upgrade
+
+    _log(f"  delivery={run.dir_delivery.rstrip('/').split('/')[-1]}")
+    _log(f"  supply={run.dir_supply.rstrip('/').split('/')[-1]}")
+
+    # --- Electric bills ---
+    t = _log("  Reading elec_bills_year_target.csv (delivery)...")
+    elec_delivery_df = cast(
+        pl.DataFrame, scan(f"{run.dir_delivery}/{ELEC_BILLS_CSV}").collect()
+    )
+    _log_done("  Reading elec delivery", t, f"{elec_delivery_df.height} rows")
+
+    t = _log("  Reading elec_bills_year_target.csv (supply)...")
+    elec_supply_df = cast(
+        pl.DataFrame, scan(f"{run.dir_supply}/{ELEC_BILLS_CSV}").collect()
+    )
+    _log_done("  Reading elec supply", t, f"{elec_supply_df.height} rows")
+
+    elec_d_ids = set(elec_delivery_df[BLDG_ID].unique().to_list())
+    elec_s_ids = set(elec_supply_df[BLDG_ID].unique().to_list())
+    _assert_building_match(
+        "elec_delivery", elec_d_ids, "elec_supply", elec_s_ids, utility
+    )
+    _assert_building_match("elec_bills", elec_d_ids, "metadata", meta_bldg_ids, utility)
+    _assert_rows_per_building(elec_delivery_df, 13, "elec_delivery", utility)
+    _assert_rows_per_building(elec_supply_df, 13, "elec_supply", utility)
+
+    # Validate weights match
+    weight_check = elec_delivery_df.select(
+        BLDG_ID, "month", pl.col("weight").alias("w_d")
+    ).join(
+        elec_supply_df.select(BLDG_ID, "month", pl.col("weight").alias("w_s")),
+        on=[BLDG_ID, "month"],
+        how="inner",
+    )
+    weight_diff = (weight_check["w_d"] - weight_check["w_s"]).abs()
+    n_weight_diff = (weight_diff > 1e-9).sum()
+    if n_weight_diff > 0:
+        raise AssertionError(
+            f"[{utility}] Weights differ between delivery and supply elec bills: "
+            f"{n_weight_diff} rows, max diff={weight_diff.max()}"
+        )
+
+    # --- Electric decomposition ---
+    t = _log("  Reading fixed charges from tariff_final_config.json...")
+    fixed_charges_df = _read_fixed_charges(run.dir_delivery, meta_bldg_ids)
+    n_unique_fc = fixed_charges_df["elec_fixed_charge_monthly"].n_unique()
+    _log_done("  Reading fixed charges", t, f"{n_unique_fc} distinct value(s)")
+
+    t = _log("  Computing electric bill decomposition...")
+    elec = (
+        elec_delivery_df.select(
+            BLDG_ID,
+            "month",
+            "weight",
+            pl.col(BILL_LEVEL).alias("bill_delivery"),
+        )
+        .join(
+            elec_supply_df.select(
+                BLDG_ID,
+                "month",
+                pl.col(BILL_LEVEL).alias("bill_supply"),
+            ),
+            on=[BLDG_ID, "month"],
+            how="inner",
+        )
+        .join(fixed_charges_df, on=BLDG_ID, how="inner")
+        .with_columns(
+            pl.when(pl.col("month") == ANNUAL_MONTH)
+            .then(pl.col("elec_fixed_charge_monthly") * 12)
+            .otherwise(pl.col("elec_fixed_charge_monthly"))
+            .alias("elec_fixed_charge"),
+        )
+        .with_columns(
+            (pl.col("bill_delivery") - pl.col("elec_fixed_charge")).alias(
+                "elec_delivery_bill"
+            ),
+            (pl.col("bill_supply") - pl.col("bill_delivery")).alias("elec_supply_bill"),
+            pl.col("bill_supply").alias("elec_total_bill"),
+        )
+        .select(
+            BLDG_ID,
+            "month",
+            "weight",
+            "elec_fixed_charge",
+            "elec_delivery_bill",
+            "elec_supply_bill",
+            "elec_total_bill",
+        )
+    )
+    _log_done("  Electric decomposition", t, f"{elec.height} rows")
+
+    # --- Gas bills (computed post-hoc from tariff JSONs + ResStock consumption) ---
+    t = _log("  Computing gas bills from tariff JSONs...")
+    gas_tariff_map = load_gas_tariff_map(state, utility, upgrade)
+    gas_map_ids = set(gas_tariff_map[BLDG_ID].to_list())
+    _assert_building_match(
+        "gas_tariff_map", gas_map_ids, "metadata", meta_bldg_ids, utility
+    )
+
+    # --- Load curves (shared by gas + oil/propane) ---
+    t = _log(f"  Reading load_curve_monthly (local, {n_bldgs} buildings)...")
+    load_curves = scan_load_curves_for_utility(
+        path_resstock_base, state.upper(), upgrade, utility, "monthly"
+    )
+    _log_done("  Reading load curves", t)
+
+    gas = cast(
+        pl.DataFrame,
+        compute_gas_bills(
+            load_curves, gas_tariff_map, gas_rate_table, gas_fixed_charges
+        ).collect(),
+    )
+    _log_done("  Gas bills", t, f"{gas.height} rows")
+
+    gas_ids = set(gas[BLDG_ID].unique().to_list())
+    _assert_building_match("gas_bills", gas_ids, "elec_bills", elec_d_ids, utility)
+    _assert_rows_per_building(gas, 13, "gas_bills", utility)
+
+    n_gas = gas.filter(
+        (pl.col("month") != ANNUAL_MONTH) & (pl.col("gas_total_bill") > 0)
+    )[BLDG_ID].n_unique()
+    _log(f"  Buildings with nonzero gas: {n_gas}")
+
+    # --- Oil and propane bills ---
+    t = _log("  Computing oil and propane bills...")
+    fuel_bills = cast(
+        pl.DataFrame, compute_fuel_bills(load_curves, monthly_prices).collect()
+    )
+    _log_done("  Oil/propane bills", t, f"{fuel_bills.height} rows")
+
+    fuel_ids = set(fuel_bills[BLDG_ID].unique().to_list())
+    _assert_building_match("load_curves", fuel_ids, "metadata", meta_bldg_ids, utility)
+
+    n_oil = fuel_bills.filter(
+        (pl.col("month") != ANNUAL_MONTH) & (pl.col("oil_total_bill") > 0)
+    )[BLDG_ID].n_unique()
+    n_propane = fuel_bills.filter(
+        (pl.col("month") != ANNUAL_MONTH) & (pl.col("propane_total_bill") > 0)
+    )[BLDG_ID].n_unique()
+    _log(f"  Buildings with nonzero oil: {n_oil}, propane: {n_propane}")
+
+    _assert_no_nulls(fuel_bills, ["oil_total_bill", "propane_total_bill"], utility)
+
+    # --- Join all components ---
+    t = _log("  Joining components...")
+    joined_pre = (
+        elec.join(gas, on=[BLDG_ID, "month"], how="inner")
+        .join(fuel_bills, on=[BLDG_ID, "month"], how="inner")
+        .join(
+            metadata_for_utility.select(META_COLS),
+            on=BLDG_ID,
+            how="inner",
+        )
+        .with_columns(
+            (
+                pl.col("elec_total_bill")
+                + pl.col("gas_total_bill")
+                + pl.col("propane_total_bill")
+                + pl.col("oil_total_bill")
+            ).alias("energy_total_bill"),
+            pl.lit(int(upgrade)).alias("upgrade"),
+        )
+        .with_columns(
+            pl.when(pl.col("postprocess_group.has_hp"))
+            .then(pl.lit("heat_pump"))
+            .when(pl.col("heats_with_electricity"))
+            .then(pl.lit("electrical_resistance"))
+            .when(pl.col("heats_with_natgas"))
+            .then(pl.lit("natgas"))
+            .when(pl.col("heats_with_oil") | pl.col("heats_with_propane"))
+            .then(pl.lit("delivered_fuels"))
+            .otherwise(pl.lit("other"))
+            .alias("postprocess_group.heating_type_v2"),
+        )
+    )
+    joined = _attach_baseline_columns(
+        joined_pre,
+        state_lower=state,
+        utility=utility,
+        batch=batch,
+        segment=run.segment,
+        baseline=baseline,
+        baseline_upgrade=baseline_upgrade,
+        storage_options=storage_options,
+    ).select(OUTPUT_COLS)
+    _log_done("  Joining components", t, f"{joined.height} rows")
+
+    expected_rows = n_bldgs * 13
+    if joined.height != expected_rows:
+        raise AssertionError(
+            f"[{utility}] Expected {expected_rows} rows ({n_bldgs} bldgs * 13), "
+            f"got {joined.height}"
+        )
+
+    _assert_identity(
+        joined,
+        "elec_total_bill",
+        ["elec_fixed_charge", "elec_delivery_bill", "elec_supply_bill"],
+        FLOAT_TOL,
+        utility,
+    )
+    _assert_identity(
+        joined,
+        "gas_total_bill",
+        ["gas_fixed_charge", "gas_volumetric_bill"],
+        FLOAT_TOL,
+        utility,
+    )
+    bill_cols = [
+        "weight",
+        "elec_fixed_charge",
+        "elec_delivery_bill",
+        "elec_supply_bill",
+        "elec_total_bill",
+        *BASELINE_COLS,
+        "gas_fixed_charge",
+        "gas_volumetric_bill",
+        "gas_total_bill",
+        "propane_total_bill",
+        "oil_total_bill",
+        "energy_total_bill",
+    ]
+    _assert_no_nulls(joined, bill_cols, utility)
+
+    return joined
+
+
+def _write_parquet_dir(df: pl.DataFrame, output_s3: str) -> None:
+    """Write one parquet file to an S3 prefix."""
+    tmp_dir = Path(tempfile.mkdtemp(prefix="master_bills_"))
+    try:
+        df.write_parquet(tmp_dir / "data.parquet")
+        subprocess.run(
+            ["aws", "s3", "sync", str(tmp_dir), output_s3],
+            check=True,
+            capture_output=True,
+        )
+    finally:
+        import shutil
+
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def _write_hive_partitioned(
+    df: pl.DataFrame, output_s3: str, partition_col: str
+) -> None:
+    """Write a Hive-partitioned dataset (one parquet per partition value) to S3."""
+    tmp_dir = Path(tempfile.mkdtemp(prefix="master_bills_all_"))
+    try:
+        for value, part_df in df.group_by(partition_col):
+            part_dir = tmp_dir / f"{partition_col}={value[0]}"
+            part_dir.mkdir(parents=True, exist_ok=True)
+            part_df.drop(partition_col).write_parquet(part_dir / "data.parquet")
+        subprocess.run(
+            ["aws", "s3", "sync", str(tmp_dir), output_s3],
+            check=True,
+            capture_output=True,
+        )
+    finally:
+        import shutil
+
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build master bills tables for every scenario/stage in a "
+        "Prefect pipeline batch.",
+    )
+    parser.add_argument("--state", required=True, help="State code (e.g. md)")
+    parser.add_argument(
+        "--batch",
+        required=True,
+        help="Batch name as passed to run_pipeline.py (e.g. md_20260803_a).",
+    )
+    parser.add_argument(
+        "--utilities",
+        default=None,
+        help="Comma-separated utilities to process (default: all from state.env). "
+        "Each needs a pipeline YAML at "
+        "{state}/config/scenarios/pipeline_{utility}.yaml.",
+    )
+    parser.add_argument(
+        "--scenarios",
+        nargs="*",
+        default=None,
+        help="Optional scenario names to process (space-separated). Omit for all.",
+    )
+    parser.add_argument(
+        "--path-heating-fuel-prices",
+        default="s3://data.sb/eia/heating_fuel_prices/",
+        help="S3 path to Hive-partitioned EIA heating fuel prices.",
+    )
+    parser.add_argument(
+        "--price-year", type=int, default=2024, help="Year for EIA fuel prices."
+    )
+    parser.add_argument(
+        "--calculate-lmi",
+        action="store_true",
+        help="If set, append LMI discount columns before writing master bills.",
+    )
+    parser.add_argument(
+        "--lmi-fpl-year",
+        type=int,
+        default=2025,
+        help="FPL/SMI guideline year for LMI discount calculation (used with --calculate-lmi).",
+    )
+    parser.add_argument(
+        "--lmi-cpi-s3-path",
+        default="s3://data.sb/fred/cpi/",
+        help="S3 path to CPI parquet for LMI discount calculation (used with --calculate-lmi).",
+    )
+    parser.add_argument(
+        "--lmi-participation-rates",
+        type=float,
+        nargs="+",
+        default=[1.0],
+        help="One or more participation fractions (0–1). Each rate produces a separate "
+        "column set (e.g. --lmi-participation-rates 1.0 0.4 → columns for p100 and p40). "
+        "Used with --calculate-lmi.",
+    )
+    parser.add_argument(
+        "--lmi-participation-mode",
+        choices=["uniform", "weighted"],
+        default="weighted",
+        help="Participation sampling mode for LMI discounts (used with --calculate-lmi).",
+    )
+    parser.add_argument(
+        "--lmi-seed",
+        type=int,
+        default=42,
+        help="RNG seed for LMI participation sampling (used with --calculate-lmi).",
+    )
+    parser.add_argument(
+        "--lmi-calculation-type",
+        choices=["monthly", "budget"],
+        default="budget",
+        help="LMI bill calculation method (used with --calculate-lmi).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    global _t0
+    _t0 = time.monotonic()
+    args = _parse_args()
+
+    state = args.state.lower()
+    state_upper = state.upper()
+    utilities = args.utilities.split(",") if args.utilities else _read_utilities(state)
+    storage_options = get_aws_storage_options()
+
+    _log(
+        f"Building master bills: state={state_upper}, batch={args.batch}, "
+        f"utilities={utilities}"
+    )
+    if args.calculate_lmi:
+        _log(
+            "  LMI discounts enabled: "
+            f"rates={args.lmi_participation_rates}, "
+            f"mode={args.lmi_participation_mode}, "
+            f"calculation={args.lmi_calculation_type}, "
+            f"seed={args.lmi_seed}"
+        )
+
+    # --- Resolve the batch: configs, baseline, and completed run pairs ---
+    configs = _load_configs(state, utilities)
+    baseline, baseline_upgrade = _resolve_baseline(state, configs)
+    run_pairs = _resolve_run_pairs(configs, args.batch, scenarios=args.scenarios)
+    segments = _ordered_segments(run_pairs, baseline)
+    _log(f"Baseline segment: {baseline} (upgrade {baseline_upgrade})")
+    _log(f"Build order: {segments}")
+
+    # --- Load shared data ---
+    t = _log(f"Loading gas tariffs for {state}...")
+    gas_tariffs = load_gas_tariffs(state)
+    gas_rate_table = build_rate_table(gas_tariffs)
+    gas_fixed_charges = build_fixed_charge_table(gas_tariffs)
+    _log_done(
+        "Loading gas tariffs",
+        t,
+        f"{len(gas_tariffs)} tariffs, {gas_rate_table.height} rate rows",
+    )
+
+    t = _log(
+        f"Loading EIA fuel prices (state={state_upper}, year={args.price_year})..."
+    )
+    monthly_prices = load_monthly_fuel_prices(
+        args.path_heating_fuel_prices, state_upper, args.price_year
+    )
+    _log_done("Loading EIA fuel prices", t)
+
+    metadata_by_base: dict[str, pl.DataFrame] = {}
+    for utility, config in configs.items():
+        base = config.run_defaults.resstock_base.rstrip("/")
+        if base in metadata_by_base:
+            continue
+        t = _log(f"Loading metadata from {base} (upgrade {METADATA_UPGRADE})...")
+        metadata_by_base[base] = _load_metadata(base, state_upper)
+        _log_done("Loading metadata", t, f"{metadata_by_base[base].height} rows")
+
+    bldgs_per_utility: dict[str, int] = {}
+    for utility, config in configs.items():
+        metadata = metadata_by_base[config.run_defaults.resstock_base.rstrip("/")]
+        n = metadata.filter(pl.col("sb.electric_utility") == utility)[
+            BLDG_ID
+        ].n_unique()
+        bldgs_per_utility[utility] = n
+        _log(f"  {utility}: {n} buildings")
+
+    output_base_s3 = s3_uri(next(iter(configs.values())).output_base).rstrip("/")
+
+    # --- One master table per segment, baseline first ---
+    for seg_i, segment in enumerate(segments, 1):
+        seg_utilities = [u for u in utilities if segment in run_pairs.get(u, {})]
+        _log(
+            f"=== Segment {seg_i}/{len(segments)}: {segment} "
+            f"({len(seg_utilities)} utility/ies: {seg_utilities}) ==="
+        )
+
+        upgrades = {run_pairs[u][segment].upgrade for u in seg_utilities}
+        if len(upgrades) > 1:
+            raise ValueError(
+                f"Segment {segment} maps to multiple upgrades across utilities "
+                f"({sorted(upgrades)}); pipeline YAMLs disagree on resstock upgrades."
+            )
+        upgrade = next(iter(upgrades))
+
+        all_dfs: list[pl.DataFrame] = []
+        for i, utility in enumerate(seg_utilities, 1):
+            config = configs[utility]
+            base = config.run_defaults.resstock_base.rstrip("/")
+            _log(f"Processing utility {i}/{len(seg_utilities)}: {utility}")
+
+            df = _process_utility(
+                utility=utility,
+                state=state,
+                run=run_pairs[utility][segment],
+                metadata_for_utility=metadata_by_base[base].filter(
+                    pl.col("sb.electric_utility") == utility
+                ),
+                monthly_prices=monthly_prices,
+                path_resstock_base=base,
+                gas_rate_table=gas_rate_table,
+                gas_fixed_charges=gas_fixed_charges,
+                batch=args.batch,
+                baseline=baseline,
+                baseline_upgrade=baseline_upgrade,
+                storage_options=storage_options,
+            )
+
+            per_util_output_s3 = (
+                f"{output_base_s3}/{state}/{utility}/{args.batch}/{segment}/"
+                f"comb_bills_year_target/"
+            )
+            t_util = _log(f"  Writing per-utility output to {per_util_output_s3}...")
+            _write_parquet_dir(df, per_util_output_s3)
+            _log_done(f"  Writing per-utility {utility}", t_util)
+
+            all_dfs.append(df)
+
+        # --- Concatenate ---
+        t = _log("Concatenating all utilities...")
+        master = pl.concat(all_dfs)
+        _log_done(
+            "Concatenating",
+            t,
+            f"{master.height} rows, {master[BLDG_ID].n_unique()} buildings",
+        )
+
+        # --- Final validation ---
+        t = _log("Validating final table...")
+        final_bldg_count = master[BLDG_ID].n_unique()
+        expected_bldgs = sum(bldgs_per_utility[u] for u in seg_utilities)
+        if final_bldg_count != expected_bldgs:
+            raise AssertionError(
+                f"Final building count {final_bldg_count} != expected "
+                f"{expected_bldgs} (across {len(seg_utilities)} utilities)"
+            )
+
+        per_util_check = master.group_by("sb.electric_utility").agg(
+            pl.col(BLDG_ID).n_unique().alias("n_bldgs")
+        )
+        for row in per_util_check.iter_rows(named=True):
+            u = row["sb.electric_utility"]
+            actual = row["n_bldgs"]
+            expected = bldgs_per_utility.get(u, -1)
+            if actual != expected:
+                raise AssertionError(
+                    f"Utility {u}: expected {expected} buildings, got {actual}"
+                )
+
+        _assert_identity(
+            master,
+            "energy_total_bill",
+            [
+                "elec_total_bill",
+                "gas_total_bill",
+                "propane_total_bill",
+                "oil_total_bill",
+            ],
+            FLOAT_TOL,
+            "ALL",
+        )
+        _log_done("Validation", t)
+
+        # --- Optional LMI discount augmentation ---
+        if args.calculate_lmi:
+            master = _apply_lmi_discounts_to_master(
+                master,
+                state_upper=state_upper,
+                utilities=seg_utilities,
+                upgrade=upgrade,
+                path_resstock_release=configs[
+                    seg_utilities[0]
+                ].run_defaults.resstock_base,
+                lmi_fpl_year=args.lmi_fpl_year,
+                lmi_cpi_s3_path=args.lmi_cpi_s3_path,
+                lmi_participation_rates=args.lmi_participation_rates,
+                lmi_participation_mode=args.lmi_participation_mode,
+                lmi_seed=args.lmi_seed,
+                lmi_calculation_type=args.lmi_calculation_type,
+            )
+
+        # --- Write output (Hive-partitioned parquet) ---
+        output_s3 = (
+            f"{output_base_s3}/{state}/all_utilities/{args.batch}/{segment}/"
+            f"comb_bills_year_target/"
+        )
+        t = _log(f"Writing to {output_s3}...")
+        _write_hive_partitioned(master, output_s3, "sb.electric_utility")
+        _log_done("Writing", t)
+
+    total_elapsed = time.monotonic() - _t0
+    mm, ss = divmod(int(total_elapsed), 60)
+    _log(f"Done: {len(segments)} segment(s) (total: {mm}m {ss}s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/post/build_master_bills_prefect.py
+++ b/utils/post/build_master_bills_prefect.py
@@ -79,6 +79,13 @@ from utils.post.io import (
     scan,
     scan_load_curves_for_utility,
 )
+from utils.post.master_metadata import (
+    ATTR_COLS,
+    METADATA_UPGRADE,
+    UTILITY_COLS,
+    heating_type_v2,
+    load_metadata,
+)
 from utils.post.pipeline_runs import (
     RunPair,
     baseline_segment,
@@ -93,24 +100,7 @@ from utils.post.pipeline_runs import (
 
 ELEC_BILLS_CSV = "bills/elec_bills_year_target.csv"
 
-# Building attributes are read from the baseline upgrade on every segment, so a
-# home's pre-retrofit heating type stays sliceable on calibrated segments (where
-# ResStock marks every building as a heat pump).  The ``upgrade`` column is set
-# from the segment's own stage, not from here.
-METADATA_UPGRADE = "00"
-
-ATTR_COLS = [
-    "postprocess_group.has_hp",
-    "postprocess_group.heating_type",
-    "heats_with_electricity",
-    "heats_with_natgas",
-    "heats_with_oil",
-    "heats_with_propane",
-    "in.representative_income",
-    "in.hvac_cooling_partial_space_conditioning",
-]
-
-META_COLS = [BLDG_ID, "sb.electric_utility", "sb.gas_utility", *ATTR_COLS]
+META_COLS = [BLDG_ID, *UTILITY_COLS, *ATTR_COLS]
 
 OUTPUT_COLS = [
     BLDG_ID,
@@ -177,27 +167,6 @@ def _read_utilities(state: str) -> list[str]:
         if line.startswith("UTILITIES="):
             return line.split("=", 1)[1].split(",")
     raise ValueError(f"UTILITIES not found in {env_file}")
-
-
-def _load_metadata(path_resstock_base: str, state_upper: str) -> pl.DataFrame:
-    """Utility assignment joined to baseline building attributes.
-
-    ``utility_assignment.parquet`` carries only the electric/gas utility mapping
-    in newer ResStock releases, so attributes come from the baseline upgrade's
-    ``metadata-sb.parquet``.  Older releases have those attributes on the
-    assignment table too; they are ignored in favour of one code path.
-    """
-    base = path_resstock_base.rstrip("/")
-    assignment = pl.scan_parquet(
-        f"{base}/metadata_utility/state={state_upper}/utility_assignment.parquet"
-    ).select(BLDG_ID, "sb.electric_utility", "sb.gas_utility")
-    attributes = pl.scan_parquet(
-        f"{base}/metadata/state={state_upper}/upgrade={METADATA_UPGRADE}/metadata-sb.parquet"
-    ).select(BLDG_ID, *ATTR_COLS)
-    return cast(
-        pl.DataFrame,
-        assignment.join(attributes, on=BLDG_ID, how="inner").collect(),
-    )
 
 
 def _s3_get_json(uri: str) -> dict:
@@ -735,18 +704,7 @@ def _process_utility(
             ).alias("energy_total_bill"),
             pl.lit(int(upgrade)).alias("upgrade"),
         )
-        .with_columns(
-            pl.when(pl.col("postprocess_group.has_hp"))
-            .then(pl.lit("heat_pump"))
-            .when(pl.col("heats_with_electricity"))
-            .then(pl.lit("electrical_resistance"))
-            .when(pl.col("heats_with_natgas"))
-            .then(pl.lit("natgas"))
-            .when(pl.col("heats_with_oil") | pl.col("heats_with_propane"))
-            .then(pl.lit("delivered_fuels"))
-            .otherwise(pl.lit("other"))
-            .alias("postprocess_group.heating_type_v2"),
-        )
+        .with_columns(heating_type_v2())
     )
     joined = _attach_baseline_columns(
         joined_pre,
@@ -976,7 +934,7 @@ def main() -> None:
         if base in metadata_by_base:
             continue
         t = _log(f"Loading metadata from {base} (upgrade {METADATA_UPGRADE})...")
-        metadata_by_base[base] = _load_metadata(base, state_upper)
+        metadata_by_base[base] = load_metadata(base, state_upper)
         _log_done("Loading metadata", t, f"{metadata_by_base[base].height} rows")
 
     bldgs_per_utility: dict[str, int] = {}

--- a/utils/post/master_metadata.py
+++ b/utils/post/master_metadata.py
@@ -1,0 +1,68 @@
+"""Building metadata for the master tables.
+
+Attributes are always read from the **baseline** ResStock upgrade, on every
+segment.  ResStock marks every building in the heat-pump upgrade as
+``has_hp = true`` with ``heating_type = heat_pump``, so taking a calibrated
+segment's own upgrade would erase what the home heated with before the
+retrofit — the dimension most analyses slice on.  The ``upgrade`` column in the
+master tables identifies the stage instead.
+
+``utility_assignment.parquet`` carries only the utility mapping in newer
+ResStock releases (older ones repeat the full upgrade-0 metadata on it), so the
+attributes come from the baseline upgrade's ``metadata-sb.parquet`` for every
+state.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import polars as pl
+
+from utils.post.io import BLDG_ID
+
+METADATA_UPGRADE = "00"
+
+UTILITY_COLS = ["sb.electric_utility", "sb.gas_utility"]
+
+ATTR_COLS = [
+    "postprocess_group.has_hp",
+    "postprocess_group.heating_type",
+    "heats_with_electricity",
+    "heats_with_natgas",
+    "heats_with_oil",
+    "heats_with_propane",
+    "in.representative_income",
+    "in.hvac_cooling_partial_space_conditioning",
+]
+
+
+def load_metadata(path_resstock_base: str, state_upper: str) -> pl.DataFrame:
+    """Utility assignment joined to baseline building attributes, one row per building."""
+    base = path_resstock_base.rstrip("/")
+    assignment = pl.scan_parquet(
+        f"{base}/metadata_utility/state={state_upper}/utility_assignment.parquet"
+    ).select(BLDG_ID, *UTILITY_COLS)
+    attributes = pl.scan_parquet(
+        f"{base}/metadata/state={state_upper}/upgrade={METADATA_UPGRADE}/metadata-sb.parquet"
+    ).select(BLDG_ID, *ATTR_COLS)
+    return cast(
+        pl.DataFrame,
+        assignment.join(attributes, on=BLDG_ID, how="inner").collect(),
+    )
+
+
+def heating_type_v2() -> pl.Expr:
+    """Coarser heating classification derived from HP status and fuel flags."""
+    return (
+        pl.when(pl.col("postprocess_group.has_hp"))
+        .then(pl.lit("heat_pump"))
+        .when(pl.col("heats_with_electricity"))
+        .then(pl.lit("electrical_resistance"))
+        .when(pl.col("heats_with_natgas"))
+        .then(pl.lit("natgas"))
+        .when(pl.col("heats_with_oil") | pl.col("heats_with_propane"))
+        .then(pl.lit("delivered_fuels"))
+        .otherwise(pl.lit("other"))
+        .alias("postprocess_group.heating_type_v2")
+    )

--- a/utils/post/pipeline_runs.py
+++ b/utils/post/pipeline_runs.py
@@ -199,7 +199,18 @@ def read_run_dir(batch_dir_path: str, run_name: str) -> str | None:
     local = Path(batch_dir_path) / relative
     if local.is_file():
         return local.read_text().strip()
-    return _s3_read_text(f"{s3_uri(batch_dir_path).rstrip('/')}/{relative}")
+    remote = _maybe_s3_uri(batch_dir_path)
+    if remote is None:
+        return None
+    return _s3_read_text(f"{remote.rstrip('/')}/{relative}")
+
+
+def _maybe_s3_uri(path: str | Path) -> str | None:
+    """``s3_uri`` for paths that live on S3, None for purely local ones."""
+    try:
+        return s3_uri(path)
+    except ValueError:
+        return None
 
 
 def _s3_read_text(uri: str) -> str | None:

--- a/utils/post/pipeline_runs.py
+++ b/utils/post/pipeline_runs.py
@@ -1,0 +1,217 @@
+"""Run discovery for the Prefect-native master-table builders.
+
+The Prefect pipeline records every completed CAIRO run in
+``{batch_dir}/.runs/{canonical_run_name}.path`` — a one-line file holding the
+timestamped output directory.  Post-processing consumes those runs in
+delivery+supply pairs, one pair per ``(scenario, stage)``, so this module turns
+a pipeline YAML plus a batch name into the pairs a builder should process.
+
+Master tables are keyed by ``{scenario}_{stage}`` (e.g. ``default_precalc``),
+which replaces the legacy ``run_{delivery}+{supply}`` folder name.
+
+Nothing here imports Prefect: the builders are plain CLIs invoked from Just.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from rate_design.hp_rates.pipeline_config import (
+    HP_RATES_DIR,
+    PipelineConfig,
+    canonical_run_name,
+)
+
+STAGES: tuple[str, ...] = ("precalc", "calibrated")
+VARIANTS: tuple[str, ...] = ("delivery", "supply")
+
+_FUSE_PREFIX = "/data.sb/"
+_S3_PREFIX = "s3://data.sb/"
+
+
+def pipeline_yaml_path(state: str, utility: str) -> Path:
+    """Locate a utility's pipeline YAML by convention.
+
+    ``{state}/config/scenarios/pipeline_{utility}.yaml``
+    """
+    path = (
+        HP_RATES_DIR
+        / state.lower()
+        / "config"
+        / "scenarios"
+        / f"pipeline_{utility}.yaml"
+    )
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"No pipeline YAML for utility {utility!r} at {path}. "
+            f"Post-processing resolves one YAML per utility by convention."
+        )
+    return path
+
+
+def s3_uri(path: str | Path) -> str:
+    """Translate a ``/data.sb`` FUSE path to its ``s3://`` URI (idempotent).
+
+    CAIRO run directories are recorded as FUSE paths, but the builders read
+    them with polars / boto3, which want S3 URIs.
+    """
+    text = str(path)
+    if text.startswith("s3://"):
+        return text
+    if text.rstrip("/") == "/data.sb":
+        return _S3_PREFIX
+    if text.startswith(_FUSE_PREFIX):
+        return _S3_PREFIX + text[len(_FUSE_PREFIX) :]
+    raise ValueError(
+        f"Cannot map {text!r} to an S3 URI: expected an s3:// URI or a path "
+        f"under {_FUSE_PREFIX}. Master tables are only written to S3."
+    )
+
+
+def batch_dir(config: PipelineConfig, batch: str) -> str:
+    """The batch directory holding one utility's runs and its ``.runs/`` index."""
+    return f"{config.output_base.rstrip('/')}/{config.state}/{config.utility}/{batch}"
+
+
+def master_segment(scenario: str, stage: str) -> str:
+    """The master-table folder name for one (scenario, stage)."""
+    return f"{scenario}_{stage}"
+
+
+def upgrade_for_stage(config: PipelineConfig, stage: str) -> str:
+    """The ResStock upgrade a stage represents (precalc/calibrated are 1-1 with it)."""
+    if stage == "precalc":
+        return config.run_defaults.upgrade_precalc
+    if stage == "calibrated":
+        return config.run_defaults.upgrade_calibrated
+    raise ValueError(f"Unknown stage {stage!r}; expected one of {list(STAGES)}")
+
+
+def baseline_segment(config: PipelineConfig, yaml_path: Path | str) -> str:
+    """The ``{scenario}_{stage}`` segment whose bills every other run compares to."""
+    baseline = config.bill_change_baseline
+    if baseline is None:
+        raise ValueError(
+            f"{yaml_path} has no bill_change_baseline block, so baseline bill "
+            f"columns cannot be resolved. Add, for example:\n"
+            f"  bill_change_baseline:\n"
+            f"    scenario: default\n"
+            f"    stage: precalc"
+        )
+    return baseline.segment
+
+
+@dataclass(frozen=True, slots=True)
+class RunPair:
+    """The delivery + supply runs that together make one master-table segment."""
+
+    scenario: str
+    stage: str
+    upgrade: str
+    dir_delivery: str
+    dir_supply: str
+
+    @property
+    def segment(self) -> str:
+        return master_segment(self.scenario, self.stage)
+
+
+def expected_segments(
+    config: PipelineConfig, *, scenarios: Iterable[str] | None = None
+) -> list[str]:
+    """Every ``{scenario}_{stage}`` the pipeline YAML declares, in YAML order."""
+    names = list(config.scenarios) if scenarios is None else list(scenarios)
+    for name in names:
+        config.scenario(name)  # raises KeyError on a typo
+    return [master_segment(name, stage) for name in names for stage in STAGES]
+
+
+def find_run_pairs(
+    config: PipelineConfig,
+    batch: str,
+    *,
+    scenarios: Iterable[str] | None = None,
+) -> dict[str, RunPair]:
+    """Map ``{scenario}_{stage}`` to its run pair for one utility's batch.
+
+    A (scenario, stage) whose runs are both absent is omitted, so a partially
+    run batch can still be post-processed in one command.  A pair with only one
+    variant complete raises: that segment can never be built, and silently
+    dropping it would hide a failed CAIRO run.
+    """
+    root = batch_dir(config, batch)
+    names = list(config.scenarios) if scenarios is None else list(scenarios)
+
+    pairs: dict[str, RunPair] = {}
+    for name in names:
+        scenario = config.scenario(name)
+        for stage in STAGES:
+            run_names = {
+                variant: canonical_run_name(
+                    config.state, config.utility, scenario.name, stage, variant
+                )
+                for variant in VARIANTS
+            }
+            delivery = read_run_dir(root, run_names["delivery"])
+            supply = read_run_dir(root, run_names["supply"])
+            if delivery is None and supply is None:
+                continue
+            if delivery is None or supply is None:
+                missing = "delivery" if delivery is None else "supply"
+                raise FileNotFoundError(
+                    f"{config.utility} {master_segment(scenario.name, stage)}: the "
+                    f"{missing} run never completed (no index file under "
+                    f"{root}/.runs/), but the other variant did. Re-run the "
+                    f"pipeline for this scenario before post-processing."
+                )
+            segment = master_segment(scenario.name, stage)
+            pairs[segment] = RunPair(
+                scenario=scenario.name,
+                stage=stage,
+                upgrade=upgrade_for_stage(config, stage),
+                dir_delivery=s3_uri(delivery),
+                dir_supply=s3_uri(supply),
+            )
+    return pairs
+
+
+def build_order(segments: Iterable[str], baseline: str) -> list[str]:
+    """Order segments so the baseline is built first.
+
+    Every other segment joins the baseline's master table for its
+    ``baseline_elec_*`` columns, so the baseline has to be written first.  When
+    the baseline is not part of this invocation its table is expected to exist
+    from an earlier run.
+    """
+    rest = [segment for segment in segments if segment != baseline]
+    return ([baseline] if baseline in set(segments) else []) + rest
+
+
+def read_run_dir(batch_dir_path: str, run_name: str) -> str | None:
+    """Read one run's output directory from the run index, or None if absent.
+
+    Prefers the local (FUSE) index file and falls back to S3, so the builders
+    work on hosts where ``/data.sb`` is not mounted.
+    """
+    relative = f".runs/{run_name}.path"
+    local = Path(batch_dir_path) / relative
+    if local.is_file():
+        return local.read_text().strip()
+    return _s3_read_text(f"{s3_uri(batch_dir_path).rstrip('/')}/{relative}")
+
+
+def _s3_read_text(uri: str) -> str | None:
+    """Read a small S3 text object, returning None when the key is absent."""
+    import boto3
+    from botocore.exceptions import ClientError
+
+    bucket, _, key = uri[len("s3://") :].partition("/")
+    try:
+        body = boto3.client("s3").get_object(Bucket=bucket, Key=key)["Body"].read()
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] in {"NoSuchKey", "404"}:
+            return None
+        raise
+    return body.decode().strip()


### PR DESCRIPTION
Adds Prefect-native counterparts to the legacy master-table post-processing scripts, keyed by `{scenario}_{stage}` segments instead of numeric run pairs, and discovering runs from the Prefect pipeline's `.runs/` index instead of `--run-delivery`/`--run-supply` flags. Legacy `build_master_bills.py`, `build_master_bat.py`, and `master_run12_passthrough.py` are untouched; the new scripts are self-contained duplicates.

Closes #502

## What's here

- `bill_change_baseline` — new optional block in the pipeline YAML naming the `(scenario, stage)` every run's bills are compared against (usually `default` + `precalc`). Required by post-processing, not by the pipeline itself.
- `utils/post/pipeline_runs.py` — Prefect-free run discovery: resolves each utility's pipeline YAML by convention, expands scenarios into segments, reads `.runs/{canonical_run_name}.path` index files (FUSE paths, translated to `s3://`), and pairs delivery+supply per segment. A segment missing both variants is skipped; missing only one raises.
- `utils/post/baseline_bills.py` / `utils/post/master_metadata.py` — shared helpers for the baseline bill columns and building-attribute metadata (see below).
- `utils/post/build_master_bills_prefect.py`, `utils/post/build_master_bat_prefect.py` — the new builders. One invocation processes every segment in a batch.
- `just s <state> build-all-master-prefect <batch>` (and the `-bills`/`-bat` halves) drive it. Bills before BAT, since BAT joins the baseline segment's bills.
- `tests/test_post_pipeline_runs.py` — run discovery, FUSE→S3 translation, build ordering, baseline resolution.
- Docs: `context/code/orchestration/prefect_pipeline.md` gets a new post-processing section; `AGENTS.md`'s master-table paths and column docs are updated for both the new and legacy layouts.

## Notable decisions (reviewer focus)

- **`passthrough_delivery`/`passthrough_supply` → `baseline_elec_fixed_charge`/`baseline_elec_delivery_bill`/`baseline_elec_supply_bill`.** The old name collided with "passthrough" as a residual-allocation style. The old hardcoded `upgrade == 0` filter in `master_run12_passthrough.py` is replaced by an assertion that the baseline table's `upgrade` matches what `bill_change_baseline`'s stage implies.
- **Building attributes (`has_hp`, `heating_type`, income, cooling) come from the baseline upgrade's `metadata-sb.parquet` on every segment**, joined to `utility_assignment.parquet` for the utility mapping — not the segment's own upgrade. MD's `utility_assignment.parquet` only carries the utility mapping (unlike NY/RI's, which repeats full upgrade-0 metadata), so this join is now needed on every state for one code path. Otherwise calibrated segments would report every building as a heat pump, erasing the pre-retrofit heating type most analyses slice on.
- **Calibrated-segment BAT is not specially flagged.** Those runs use a deliberately large revenue requirement so CAIRO doesn't rescale the tariff, which swamps `residual_share`/`BAT_*` (median ~$817k vs ~$1.3k in precalc) while leaving bills correct. Builders write it as CAIRO produced it; documented in `prefect_pipeline.md` as "read cross-subsidy from precalc."
- **`--batch-override`/`--output-batch` dropped.** Utilities are independent per pipeline YAML; per-utility batch mismatches aren't a case this needs to support yet.

## Verification

Ran end-to-end against `md_20260803_a` (`default` + `hp_seasonal_percustomer_passthrough`, both stages) via `just s md build-all-master-prefect md_20260803_a`. Confirmed: baseline columns exact-match the baseline table on every segment (max diff 0.0), `upgrade` correct per stage (0/2), every BAT identity holds (`BAT_m_total = BAT_m_delivery + BAT_m_supply`, `annual_bill_total ≈ economic_burden + residual_share + BAT_percustomer`). `just check` clean; full `pytest` suite passes (2 pre-existing, unrelated failures in `test_resstock_download_to_s3.py` for NY/RI, off by one building between metadata and load curves).

Made with [Cursor](https://cursor.com)